### PR TITLE
Update repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Google Group](https://img.shields.io/badge/-Google%20Group-lightgrey.svg)](https://groups.google.com/forum/#!forum/jupyter) 
 [![PyPI version](https://badge.fury.io/py/jupyter_enterprise_gateway.svg)](https://badge.fury.io/py/jupyter_enterprise_gateway) 
-[![Build Status](https://travis-ci.org/jupyter-incubator/dashboards.svg?branch=master)](https://travis-ci.org/jupyter/enterprise_gateway)
-[![Code Health](https://landscape.io/github/jupyter/enterprise_gateway/master/landscape.svg?style=flat)](https://landscape.io/github/jupyter/enterprise_gateway/master)
+[![Build Status](https://travis-ci.org/jupyter-incubator/enterprise_gateway.svg?branch=master)](https://travis-ci.org/jupyter-incubator/enterprise_gateway)
 [![Documentation Status](http://readthedocs.org/projects/jupyter-enterprise-gateway/badge/?version=latest)](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/?badge=latest)
 
 ## Overview
@@ -23,7 +22,7 @@ Gateway's extensible framework.
 * Ability to associate profiles consisting of configuration settings to a kernel for a given user
 * Persistent kernel sessions
 
-![Deployment Diagram](https://github.com/SparkTC/enterprise_gateway/blob/master/docs/source/images/deployment.png?raw=true)
+![Deployment Diagram](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/docs/source/images/deployment.png?raw=true)
 
 ## Features
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -132,7 +132,7 @@ These kernelspecs come pre-configured with YARN client and/or cluster mode. Plea
 as an example on how to update/customize your kernelspecs:
 
 ``` Bash
-wget https://github.com/SparkTC/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_2.1_scala" | awk '{print $2}')"
 

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -75,7 +75,7 @@ Here's an example of a kernel specification that uses the `DistributedProcessPro
 ```
 
 The `RemoteKernelSpec` class definition can be found in 
-[remotekernelspec.py](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/kernelspecs/remotekernelspec.py)
+[remotekernelspec.py](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/kernelspecs/remotekernelspec.py)
 
 See the [Process Proxy](#process-proxy) section for more details.
 
@@ -99,7 +99,7 @@ place of the process instance used in today's implementation.  Any interaction w
 place via the process proxy.
 
 Both `RemoteMappingKernelManager` and `RemoteKernelManager` class definitions can be found in 
-[remotemanager.py](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/kernels/remotemanager.py)
+[remotemanager.py](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/kernels/remotemanager.py)
 
 ### Process Proxy
 Process proxy classes derive from the abstract base class `BaseProcessProxyABC` - which defines the four basic 
@@ -113,7 +113,7 @@ a `process_proxy` stanza will use `LocalProcessProxy`.
 built-in subclasses of `RemoteProcessProxy` - `DistributedProcessProxy` - representing a proof of concept 
 class that remotes a kernel via ssh and `YarnClusterProcessProxy` - representing the design target of launching 
 kernels hosted as yarn applications via yarn/cluster mode.  These class definitions can be found in 
-[processproxies package](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/processproxies).
+[processproxies package](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/enterprise_gateway/services/processproxies).
 
 ![Process Class Hierarchy](images/process_proxy_hierarchy.png)
 
@@ -262,7 +262,7 @@ argument name.  However, the response address is identified by the parameter `--
 value (`{response_address}`) consists of a string of the form `<IPV4:port>` where the IPV4 address points 
 back to the Enterprise Gateway server - which is listening for a response on the provided port.
 
-Here's a [kernel.json](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/kernel.json) 
+Here's a [kernel.json](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/kernel.json) 
 file illustrating these parameters...
 
 ```json
@@ -287,9 +287,9 @@ file illustrating these parameters...
 ```
 Kernel.json files also include a `LAUNCH_OPTS:` section in the `env` stanza to allow for custom 
 parameters to be conveyed in the launcher's environment.  `LAUNCH_OPTS` are then referenced in 
-the [run.sh](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/bin/run.sh) 
+the [run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/bin/run.sh) 
 script as the initial arguments to the launcher 
-(see [launch_ipykernel.py](https://github.com/SparkTC/enterprise_gateway/blob/enterprise_gateway/etc/kernel-launchers/python/scripts/launch_ipykernel.py)) ...
+(see [launch_ipykernel.py](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernel-launchers/python/scripts/launch_ipykernel.py)) ...
 ```bash
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup_args = dict(
     name='jupyter_enterprise_gateway',
     author='Jupyter Development Team',
     author_email='jupyter@googlegroups.com',
-    url='http://github.com/SparkTC/enterprise_gateway',
+    url='http://github.com/jupyter-incubator/enterprise_gateway',
     description='A web server for spawning and communicating with remote Jupyter kernels',
     long_description='''\
 Jupyter Enterprise Gateway is a lightweight, multi-tenant, scalable and secure gateway that enables 


### PR DESCRIPTION
Many links still referenced the older repository organization - now
updated to jupyter-incubator.

Removed Code Health tab on README.md since it appears to require subscription
and neither Notebook or JupyterHub use it.