### PR TITLE
Updated PYTHONPATH in kernel.json for locally installed modules

### DIFF
--- a/etc/kernelspecs/spark_2.1_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_2.1_python_yarn_client/kernel.json
@@ -7,7 +7,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
-    "PYTHONPATH": "/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
+    "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
     "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip,PATH=/opt/anaconda2/bin:$PATH",
     "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
     "LAUNCH_OPTS": ""

--- a/etc/kernelspecs/spark_2.1_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_2.1_python_yarn_cluster/kernel.json
@@ -7,7 +7,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
-    "PYTHONPATH": "/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
+    "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
     "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip,PATH=/opt/anaconda2/bin:$PATH",
     "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "LAUNCH_OPTS": ""


### PR DESCRIPTION
Issue #193: Update PYTHONPATH in kernel.json for locally installed modules

Python modules that are installed from within a notebook cell using `!pip install --user <module-name>` get installed under `$HOME/.local/lib/python-<ver>/site-packages` folder. For the module to be successfully imported using `import <module-name>` in a notebook cell, `PYTHONPATH` defined in `kernel.json` for Python-specific kernelspecs should be augmented to include the aforementioned path.