### PR TITLE
Makefile and setup.py for PyPI release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ else
 	$(SA) $(ENV) && nosetests enterprise_gateway.tests.$(TEST)
 endif
 
-release: POST_SDIST=register upload
+release: POST_SDIST=upload
 release: bdist sdist ## Make a wheel + source release on PyPI

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+description-file=README.md


### PR DESCRIPTION
Related to issue #152 . We only need to remove the `register` in `Makefile` and add the `metadata` on `setup.cfg`.

This PR is a duplicate with another one created before the migration of our repo from private STC to here jupyter-incubator: https://github.com/jupyter-incubator/enterprise_gateway/pull/164

