### PR TITLE
Remove use remote-user command line option and env variable.

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -187,10 +187,6 @@ EnterpriseGatewayApp options
     Bracketed comma-separated list of hosts on which DistributedProcessProxy
     kernels will be launched e.g., ['host1','host2']. (EG_REMOTE_HOSTS env var -
     non-bracketed, just comma-separated)
---EnterpriseGatewayApp.remote_user=<Unicode>
-    Default: ''
-    The username used for remote operations (ssh).  Password-less ssh is
-    required.  (EG_REMOTE_USER env var)
 --EnterpriseGatewayApp.seed_uri=<Unicode>
     Default: None
     Runs the notebook (.ipynb) at the given URI on every kernel launched. No
@@ -237,16 +233,6 @@ JupyterWebsocketPersonality options
   EG_YARN_ENDPOINT=http://localhost:8088/ws/v1/cluster 
       YARN resource manager endpoint.  This value can also be specified on the 
       command line via option '--EnterpriseGatewayApp.yarn_endpoint'.  
-
-  EG_REMOTE_USER=<enterprise gateway process owner> 
-      The user name with which ssh operations are carried out under.  It is assumed
-      that password-less ssh has been configured across all targetted nodes within 
-      the cluster.  This value can also be specified on the command line via option 
-      '--EnterpriseGatewayApp.remote_user'.  
-
-  EG_REMOTE_PWD=None 
-      The password of the user specified via `EG_REMOTE_USER`.  This should only be 
-      set in situations where password-less ssh cannot be configured.   
 
   EG_REMOTE_HOSTS=localhost 
       A comma-separated list of hosts on which DistributedProcessProxy kernels will

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -288,21 +288,17 @@ the environment variable `EG_REMOTE_HOSTS`, in which case a simple comma-separat
 sufficient.  If neither value is provided and DistributedProcessProxy kernels are invoked,
 Enterprise Gateway defaults this option to `localhost`.
 
-##### Service and Remote Users
+##### Enterprise Gateway Service User
 As noted above, we recommend running Enterprise Gateway as a background task.  Normally,
-such a task is invoked from a _service user_ account identified by a non-root user (which
+such a task is invoked from a _service user_ account identified by a **non-root user** (which
 we strongly recommend be the case).  A service user typically cannot be used to login 
-with and often times has other privileges not typically granted to normal non-root users. 
+to the system, and, often times, has other privileges not typically granted to normal non-root users. 
 For Enterprise Gateway, we recommend this user be a member of the `hdfs` group (assuming 
 you're installing into a YARN cluster).
 
-To perform some of its distributed operations, Enterprise Gateway also uses a user account
-known as the _remote user_.  By default, the remote user is the user id under which 
-Enterprise Gateway is running.  As a result, we recommend that the _service user_ be the same 
-account as the _remote user_ although that is not necessary.  The requirement for the 
-remote user is that it be able to use password-less ssh across the configured _remote 
-hosts_ of the cluster.  The remote user can be specified on the command line via 
-`--EnterpriseGatewayApp.remote_user` or via the `EG_REMOTE_USER` environment variable.
+Enterprise Gateway also uses this service user account to perform some of its distributed 
+operations.  As a result, the service user must be configured to use password-less ssh 
+across the configured _remote hosts_ of the cluster.
 
 
 Amending the start script with a more complete example that includes distribution modes,

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -221,18 +221,15 @@ connection information, the primary kernel operations naturally take place over 
 This process proxy is reliant on the `--EnterpriseGatewayApp.yarn_endpoint` command line 
 option or the `EG_YARN_ENDPOINT` environment variable to determine where the YARN resource manager is located.
 
-In addition, in some cases, it requires use of the `--EnterpriseGatewayApp.remote_user` option (or 
-`EG_REMOTE_USER` envrionment variable) for performing kernel interrupt functionality.
-
 ###### DistributedProcessProxy
 Like `YarnClusterProcessProxy`, Enterprise Gateway also provides an implementation of a basic
 round-robin remoting mechanism that is part of the `DistributedProcessProxy` class.  This class
 uses the `--EnterpriseGatewayApp.remote_hosts` command line option (or `EG_REMOTE_HOSTS` 
 environment variable) to determine on which hosts a given kernel should be launched.  It uses
 a basic round-robin algorithm to index into the list of remote hosts for selecting the target
-host.  It then uses ssh (and the remote user noted previously) to launch the kernel on the 
-target host.  As a result, all kernelspec files must reside on the remote hosts in the same
-directory structure as on the Enterprise Gateway server.
+host.  It then uses ssh to launch the kernel on the target host.  As a result, all kernelspec 
+files must reside on the remote hosts in the same directory structure as on the Enterprise 
+Gateway server.
 
 It should be noted that kernels launched with this process proxy run in YARN _client_ mode - so their resources (within
 the kernel process itself) are not managed by the YARN resource manager. 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -37,10 +37,10 @@ a "Kernel error" and State: 'FAILED'.**
 
 
 - **I'm trying to launch a (Python/Scala/R) kernel in YARN Client Mode but it failed with 
-a "Kernel error" and an AuthenticationException.**
+a "Kernel error" and an `AuthenticationException`.**
     ```
     [E 2017-09-29 11:13:23.277 EnterpriseGatewayApp] Exception 'AuthenticationException' occurred 
-    when creating a SSHClient connecting to '172.xx.xxx.xxx' with user 'elyra', 
+    when creating a SSHClient connecting to 'xxx.xxx.xxx.xxx' with user 'elyra', 
     message='Authentication failed.'.
     ```
     
@@ -48,13 +48,22 @@ a "Kernel error" and an AuthenticationException.**
     ssh needs to be configured on the node that the Enterprise Gateway is running on to all other 
     worker nodes.
     
-    In general, you can look for more information in the proxy launch log for YARN Client 
-    kernels.  The default location is /tmp/jeg_proxy_launch.log and it can be configured 
-    using the environment variable `EG_PROXY_LAUNCH_LOG` during Enterprise Gateway start up. 
-    See [Starting Enterprise Gateway](getting-started.html#starting-enterprise-gateway) for an 
-    example of starting the Enterprise Gateway from a script and 
-    [Supported Environment Variables](config-options.html#supported-environment-variables) 
-    for a list of configurable environment variables.   
+    You might also see an `SSHException` indicating a similar issue.
+    ```
+    [E 2017-09-29 11:13:23.277 EnterpriseGatewayApp] Exception 'SSHException' occurred 
+    when creating a SSHClient connecting to 'xxx.xxx.xxx.xxx' with user 'elyra', 
+    message='No authentication methods available.'.
+    ```
+
+
+ In general, you can look for more information in the proxy launch log for YARN Client 
+ kernels.  The default location is /tmp/jeg_proxy_launch.log and it can be configured 
+ using the environment variable `EG_PROXY_LAUNCH_LOG` during Enterprise Gateway start up. 
+ 
+ See [Starting Enterprise Gateway](getting-started.html#starting-enterprise-gateway) for an 
+ example of starting the Enterprise Gateway from a script and 
+ [Supported Environment Variables](config-options.html#supported-environment-variables) 
+ for a list of configurable environment variables.   
 
 
 

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -57,17 +57,6 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     def remote_hosts_default(self):
         return os.getenv(self.remote_hosts_env, 'localhost').split(',')
 
-    # Remote User
-    remote_user_env = 'EG_REMOTE_USER'
-    remote_user = Unicode(config=True,
-        help="""The username used for remote operations (ssh).  Password-less ssh is required. 
-        (EG_REMOTE_USER env var)""")
-
-    # if EG_REMOTE_USER is not defined, default to the current USER, else the empty string.
-    @default('remote_user')
-    def remote_user_default(self):
-        return os.getenv(self.remote_user_env, os.getenv('USER', ''))
-
     # Yarn endpoint
     yarn_endpoint_env = 'EG_YARN_ENDPOINT'
     yarn_endpoint_default_value = 'http://localhost:8088/ws/v1/cluster'


### PR DESCRIPTION
We no longer document the use of `EG_REMOTE_USER` or
`--EnterpriseGatewayApp.remote_user` but instead that the _service user_
needs to be configured for password-less ssh.

In the code, the use of `EG_REMOTE_USER` and optional `EG_REMOTE_PWD`
is still present, but remote user defaults to `$USER` and password defaults
to `None`.  These merely exist in case we need to leverage this capability.

Added another example (`SSHException`) to the troubleshooting instance for
password-less ssh issues.

Fixes #198