### PR TITLE
Address scalability and other issues wth SSH tunnels

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -66,5 +66,37 @@ a "Kernel error" and an `AuthenticationException`.**
  for a list of configurable environment variables.   
 
 
+- **I'm trying to launch a (Python/Scala/R) kernel in YARN Client Mode with SSH tunneling enabled
+but it failed with a "Kernel error" and a SSHException.**
+    ```
+    [E 2017-10-26 11:48:20.922 EnterpriseGatewayApp] The following exception occurred waiting
+    for connection file response for KernelId 'da3d0dde-9de1-44b1-b1b4-e6f3cf52dfb9' on host
+    'remote-host-name': The authenticity of the host can't be established.
+    ```
+
+    This error indicates that fingerprint for the ECDSA key of the remote host has not been added
+    to the list of known hosts from where the SSH tunnel is being established.
+
+    For example, if the Enterprise Gateway is running on `node1` under service-user `jdoe` and
+    environment variable `EG_REMOTE_HOSTS` is set to `node2,node3,node4`, then the Kernels can be
+    launched on any of those hosts and a SSH tunnel will be established between `node1` and
+    any of the those hosts.
+
+    To address this issue, you need to perform a one-time step that requires you to login to
+    `node1` as `jdoe` and manually SSH into each of the remote hosts and accept the fingerprint
+    of the ECDSA key of the remote host to be added to the list of known hosts as shown below:
+
+    ```
+    [jdoe@node1 ~]$ ssh node2
+    The authenticity of host 'node2 (172.16.207.191)' can't be established.
+    ECDSA key fingerprint is SHA256:Mqi3txf4YiRC9nXg8a/4gQq5vC4SjWmcN1V5Z0+nhZg.
+    ECDSA key fingerprint is MD5:bc:4b:b2:39:07:98:c1:0b:b4:c3:24:38:92:7a:2d:ef.
+    Are you sure you want to continue connecting (yes/no)? yes
+    Warning: Permanently added 'node2,172.16.207.191' (ECDSA) to the list of known hosts.
+    [jdoe@node2 ~] exit
+    ```
+
+    Repeat the aforementioned step as `jdoe` on `node1` for each of the hosts listed in
+    `EG_REMOTE_HOSTS` and restart Enterprise Gateway.
 
 


### PR DESCRIPTION
Issue #168: Address scalability and other issues with SSH tunnels

Use `pexpect.spawn()` to spawn a child process to execute the SSH command. As a result, the SSH processes are no longer orphaned and become children of the parent Enterprise Gateway process. And, when the Kernel is being terminated, the Enterprise Gateway can terminate the child processes cleanly.

This commit also addresses issues where the number of child SSH processes fluctuated between 3 and 6. Now, Enterprise Gateway consistently creates 6 SSH tunnels to the Kernel process.

Also, added support for Win32 using Paramiko. This means, there is no need to expose any public APIs for time being till other use-cases emerge.

Updated troubleshooting guide to address SSHException when the fingerprint for ECDSA key is not added to the list of known hosts.