### PR TITLE
Instructions to use pip with --user in multi-tenant world

### DIFF
--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -353,6 +353,23 @@ jupyter notebook \
   --NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager
 ```
 
+### Installing Python modules from within Notebook Cell
+To be able to honor user isolation in a multi-tenant world, installing Python modules using `pip` from
+within a Notebook Cell should be done using the `--user` command-line option as shown below:
+
+```
+!pip install --user <module-name>
+```
+
+This results in the Python module to be installed in `$USER/.local/lib/python<version>/site-packages`
+folder. `PYTHONPATH` environment variable defined in `kernel.json` must include
+`$USER/.local/lib/python<version>/site-packages` folder so that the newly installed module can be
+successfully imported in a subsequent Notebook Cell as shown below:
+
+```
+import <module-name>
+```
+
 [//]: # (The most convenient)
 [//]: # (way to use a pre-configured installation of NB2KG would be using the Docker image)
 [//]: # ([biginsights/jupyter-nb-nb2kg:dev]https://hub.docker.com/r/biginsights/jupyter-nb-nb2kg/. Replace)


### PR DESCRIPTION
Instructions to use pip with --user in multi-tenant world

Issue #192: In order to honor user isolation in a multi-tenant world, it is very 
important that users do not trample on each other's environments. So, if a
Python module is being installed from within a Notebook Cell, then the
`--user` command-line option should be used as shown below:

```
!pip install --user <module-name>
```

This will result in the module to be installed under 
`$HOME/.local/lib/python<version>/site-packages` folder. Also, `PYTHONPATH`
defined in `kernel.json` should include the aforementioned path so that the
module can be imported in a subsequent Notebook Cell as shown below:

```
import <module-name>
```
