### PR TITLE
Eliminated sleep to keep SSH session alive

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -401,11 +401,11 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         """
         if sys.platform == 'win32':
             ssh_server = server + ":" + str(port)
-            return tunnel.paramiko_tunnel(local_port, remote_port, ssh_server, remote_ip, key, timeout=maxint)
+            return tunnel.paramiko_tunnel(local_port, remote_port, ssh_server, remote_ip, key)
         else:
             ssh = "ssh -p %s" % port
-            cmd = "%s -S none -L 127.0.0.1:%i:%s:%i %s sleep %i" % (
-                ssh, local_port, remote_ip, remote_port, server, maxint)
+            cmd = "%s -S none -L 127.0.0.1:%i:%s:%i %s" % (
+                ssh, local_port, remote_ip, remote_port, server)
             return pexpect.spawn(cmd, env=os.environ.copy().pop('SSH_ASKPASS', None))
 
     def receive_connection_info(self):


### PR DESCRIPTION
Eliminated sleep to keep SSH session alive

Earlier, `sleep maxint` was being used to keep the SSH session 
alive. However, even after the kernel process was closed/halted 
and the SSH processes were terminated, the  child processes 
would not get terminated. As a result, the number of child 
processes running under the service-user would keep 
increasing as more and more kernels were launched on the 
remote host.

This change eliminates the sleep child process as we no 
longer need it to keep the SSH session alive.

Addresses issue #168.