### PR TITLE
Initial docker configurtion and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 # PyCharm
 .idea/
 *.iml
+
+# Build-related
+.image_*

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-.PHONY: help build clean nuke dev dev-http docs kernelspecs install bdist sdist test release
+.PHONY: help build clean nuke dev dev-http docs install sdist test release docker_clean docker_clean_enterprise-gateway docker_clean_nb2kg docker_clean_hadoop-spark
 
 SA:=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 MAKEFILE_DIR:=${CURDIR}
 VERSION:=0.7.0.dev0
+WHEEL_FILE:=dist/jupyter_enterprise_gateway-$(VERSION)-py2.py3-none-any.whl
+WHEEL_FILES:=$(shell find . -type f ! -path "./build/*" ! -path "./etc/*" ! -path "./docs/*" ! -path "./.git/*" ! -path "./.idea/*" ! -path "./dist/*" ! -path "./.image_enterprise-gateway" ! -path "./.image_nb2kg" ! -path "./.image_hadoop-spark" )
+KERNELSPECS_FILE:=dist/jupyter_enterprise_gateway-kernelspecs-$(VERSION).tar.gz
+KERNELSPECS_FILES:=$(shell find etc/kernel* -type f -name '*')
+ENTERPRISE_GATEWAY_TAG:=dev
+NB2KG_TAG:=dev
+HADOOP_SPARK_TAG:=2.7.1-2.1.0
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -42,15 +49,17 @@ dev: ## Make a server in jupyter_websocket mode
 docs: ## Make HTML documentation
 	$(SA) $(ENV) && make -C docs html
 
-kernelspecs: ## Make a tar.gz file consisting of kernelspec files
+kernelspecs: $(KERNELSPECS_FILE) ## Make a tar.gz file consisting of kernelspec files
+
+$(KERNELSPECS_FILE): $(KERNELSPECS_FILES)
 	@mkdir -p build/kernelspecs
 	cp -r etc/kernelspecs build
 	@echo build/kernelspecs/*_python_* | xargs -t -n 1 cp -r etc/kernel-launchers/python/*
 	@echo build/kernelspecs/*_R_* | xargs -t -n 1 cp -r etc/kernel-launchers/R/*
 	@echo build/kernelspecs/*_scala_* | xargs -t -n 1 cp -r etc/kernel-launchers/scala/*
 	@mkdir -p dist
-	rm -f dist/enterprise_gateway-kernelspecs.tar.gz
-	@( cd build/kernelspecs; tar -pvczf "$(MAKEFILE_DIR)/dist/jupyter_enterprise_gateway_kernelspecs-$(VERSION).tar.gz" * )
+	rm -f dist/enterprise_gateway-kernelspecs*.tar.gz
+	@( cd build/kernelspecs; tar -pvczf "$(MAKEFILE_DIR)/$(KERNELSPECS_FILE)" * )
 
 install: ## Make a conda env with dist/*.whl and dist/*.tar.gz installed
 	-conda env remove -y -n $(ENV)-install
@@ -68,7 +77,9 @@ install: ## Make a conda env with dist/*.whl and dist/*.tar.gz installed
 			pip uninstall -y jupyter_enterprise_gateway
 	conda env remove -y -n $(ENV)-install
 
-bdist: ## Make a dist/*.whl binary distribution
+bdist: $(WHEEL_FILE) ## Make a dist/*.whl binary distribution
+
+$(WHEEL_FILE): $(WHEEL_FILES)
 	$(SA) $(ENV) && python setup.py bdist_wheel $(POST_SDIST) \
 		&& rm -rf *.egg-info
 
@@ -87,3 +98,47 @@ endif
 
 release: POST_SDIST=upload
 release: bdist sdist ## Make a wheel + source release on PyPI
+
+
+docker_images: docker_image_enterprise-gateway docker_image_nb2kg docker_image_hadoop-spark ## Build docker images
+
+docker_image_enterprise-gateway: docker_image_hadoop-spark .image_enterprise-gateway ## Build elyra/enterprise-gateway:dev docker image
+.image_enterprise-gateway: etc/docker/enterprise-gateway/* $(WHEEL_FILE) $(KERNELSPECS_FILE)
+	@make bdist kernelspecs
+	@mkdir -p build/docker/enterprise-gateway
+	cp etc/docker/enterprise-gateway/* build/docker/enterprise-gateway
+	cp dist/jupyter_enterprise_gateway* build/docker/enterprise-gateway
+	@(cd build/docker/enterprise-gateway; docker build -t elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG) . )
+	@touch .image_enterprise-gateway
+	@-docker images elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG)
+
+docker_image_nb2kg: .image_nb2kg ## Build elyra/nb2kg:dev docker image 
+.image_nb2kg: etc/docker/nb2kg/* 
+	@mkdir -p build/docker/nb2kg
+	cp etc/docker/nb2kg/* build/docker/nb2kg
+	@(cd build/docker/nb2kg; docker build -t elyra/nb2kg:$(NB2KG_TAG) . )
+	@touch .image_nb2kg
+	@-docker images elyra/nb2kg:$(NB2KG_TAG)
+
+docker_image_hadoop-spark: .image_hadoop-spark ## Build elyra/hadoop-spark:2.7.1-2.1.0 docker image
+.image_hadoop-spark: etc/docker/hadoop-spark/* 
+	@mkdir -p build/docker/hadoop-spark
+	cp etc/docker/hadoop-spark/* build/docker/hadoop-spark
+	@(cd build/docker/hadoop-spark; docker build -t elyra/hadoop-spark:$(HADOOP_SPARK_TAG) . )
+	@touch .image_hadoop-spark
+	@-docker images elyra/hadoop-spark:$(HADOOP_SPARK_TAG)
+
+docker_clean: docker_clean_enterprise-gateway docker_clean_nb2kg docker_clean_hadoop-spark ## Remove docker images
+
+docker_clean_enterprise-gateway: ## Remove elyra/enterprise-gateway:dev docker image
+	@rm -f .image_enterprise-gateway
+	@-docker rmi elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG)
+
+docker_clean_nb2kg: ## Remove elyra/nb2kg:dev docker image
+	@rm -f .image_nb2kg
+	@-docker rmi elyra/nb2kg:$(NB2KG_TAG)
+
+docker_clean_hadoop-spark: ## Remove elyra/hadoop-spark:2.7.0-2.1.0 docker image
+	@rm -f .image_hadoop-spark
+	@-docker rmi elyra/hadoop-spark:$(HADOOP_SPARK_TAG)
+

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -25,11 +25,19 @@ git clone https://github.com/jupyter/enterprise_gateway.git
 Enterprise Gateway's build environment is centered around `make` and the corresponding `Makefile`.  
 Entering `make` with no parameters yields the following:
 
-```python
+```
 activate                       eval `make activate`
 bdist                          Make a dist/*.whl binary distribution
 clean                          Make a clean source tree
 dev                            Make a server in jupyter_websocket mode
+docker_clean                   Remove docker images
+docker_clean_enterprise-gateway Remove elyra/enterprise-gateway:dev docker image
+docker_clean_hadoop-spark      Remove elyra/hadoop-spark:2.7.0-2.1.0 docker image
+docker_clean_nb2kg             Remove elyra/nb2kg:dev docker image
+docker_image_enterprise-gateway Build elyra/enterprise-gateway:dev docker image
+docker_image_hadoop-spark      Build elyra/hadoop-spark:2.7.1-2.1.0 docker image
+docker_image_nb2kg             Build elyra/nb2kg:dev docker image 
+docker_images                  Build docker images
 docs                           Make HTML documentation
 env                            Make a dev environment
 install                        Make a conda env with dist/*.whl and dist/*.tar.gz installed
@@ -38,7 +46,6 @@ nuke                           Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 sdist                          Make a dist/*.tar.gz source distribution
 test                           Make a python3 test run
-
 ```
 Some of the more useful commands are listed below.
 
@@ -47,14 +54,14 @@ Some of the more useful commands are listed below.
 Build a Python 3 conda environment containing the necessary dependencies for
 running the enterprise gateway server, running tests, and building documentation.
 
-```bash
+```
 make env
 ```
 
 By default, the env built will be named `enterprise-gateway-dev`.  To produce a different conda env, 
 you can specify the name via the `ENV=` parameter. 
 
-```bash
+```
 make ENV=my-conda-env env
 ```
 
@@ -65,7 +72,7 @@ otherwise the command will use the default environment.
 
 Build a wheel file that can then be installed via `pip install`
 
-```bash
+```
 make bdist
 ```
 
@@ -76,7 +83,7 @@ and `Toree` to demonstrate remote kernels and their corresponding launchers.  On
 `DistributedProcessProxy` while the other uses  the `YarnClusterProcessProxy`. The following makefile 
 target produces a tar file (`enterprise_gateway_kernelspecs.tar.gz`) in the `dist` directory.
 
-```bash
+```
 make kernelspecs
 ```
 
@@ -84,7 +91,7 @@ make kernelspecs
 
 Run an instance of the Enterprise Gateway server.
 
-```bash
+```
 make dev
 ```
 
@@ -94,7 +101,7 @@ Then access the running server at the URL printed in the console.
 
 Run Sphinx to build the HTML documentation.
 
-```bash
+```
 make docs
 ```
 
@@ -102,6 +109,15 @@ make docs
 
 Run the unit test suite.
 
-```bash
+```
 make test
+```
+
+### Build the docker images
+
+The following can be used to build all three docker images used within the project.  See 
+[docker images](docker.html) for specific details.
+
+```
+make docker_images
 ```

--- a/docs/source/docker.md
+++ b/docs/source/docker.md
@@ -1,0 +1,56 @@
+## Docker Images
+
+The project produces three docker images to make both testing and general usage easier:
+1. elyra/hadoop-spark
+1. elyra/enterprise-gateway
+1. elyra/nb2kg
+
+All images can be pulled from docker hub's [elyra organization](https://hub.docker.com/u/elyra/) and their 
+docker files can be found in the github repository in the appropriate directory of 
+[etc/docker](https://github.com/jupyter-incubator/enterprise_gateway/tree/master/etc/docker).
+
+Local images can also be built via `make docker_images`.
+
+### elyra/hadoop-spark
+
+The [elyra/hadoop-spark](https://hub.docker.com/r/elyra/hadoop-spark/) image is considered the base image 
+upon which [elyra/enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) is built.  It consist 
+of a Hadoop (YARN) installation that includes Spark, Java, Anaconda and various kernel installations.
+
+The tag of this image reflects the versions of the primary pieces of software (Hadoop/Spark) and we don't 
+anticipate the need to update this image regularly.
+
+The primary use of this image is to quickly build elyra/enterprise-gateway images for testing and development
+purposes.  To build a local image, run `make docker_image_hadoop-spark`.  Note: the tag for this image will
+still be `:2.7.1-2.1.0` since `elyra/enterprise-gateway` depends on this image.
+
+### elyra/enterprise-gateway
+
+Image [elyra/enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) is the primary image 
+produced by this repository.  Built on [elyra/hadoop-spark](https://hub.docker.com/r/elyra/hadoop-spark/), it
+also includes the various example kernelspecs contained in the repository.
+
+By default, this container will start with enterprise gateway running as a service user named `elyra`.  This
+user is enabled for `sudo` so that it can emulate other users where necessary.  Other users included in this 
+image are `jovyan` (the user common in most Jupyter-based images, with UID=`1000` and GID=`100`), `bob` and 
+`alice` (names commonly used in security-based examples).
+
+We plan on producing one image per release to the 
+[enterprise-gateway docker repo](https://hub.docker.com/r/elyra/enterprise-gateway/) where
+the image's tag reflects the corresponding release.  Over time, we may integrate with docker hub to produce
+this image on every build - where the commit hash becomes the tag.
+
+To build a local image, run `make docker_image_enterprise-gateway`.  Because this is a development build, the
+the tag for this image will be `:dev`.
+
+### elyra/nb2kg
+
+Image [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) is a simple image built 
+on [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/).  Because 
+enterprise gateway relies on recent NB2KG changes, it's 
+[dockerfile](https://github.com/jupyter-incubator/enterprise_gateway/tree/master/etc/docker/nb2kg/Dockerfile)
+pulls directly from the master branch in git and includes the latest NB2KG code.  The image also sets some
+of the new variables that pertain to enterprise gateway (e.g., `KG_REQUEST_TIMEOUT`, `KERNEL_USERNAME`, etc.).
+
+To build a local image, run `make docker_image_nb2kg`.  Because this is a development build, the 
+tag for this image will be `:dev`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,7 @@ the number of active kernels can be dramatically increased.
 
    contrib
    devinstall
+   docker
    roadmap
 
 .. toctree::

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,0 +1,55 @@
+FROM elyra/hadoop-spark:2.7.1-2.1.0
+
+# Install Enterprise Gateway wheel and kernelspecs
+COPY jupyter_enterprise_gateway*.whl /tmp
+RUN pip install /tmp/jupyter_enterprise_gateway*.whl && \
+	rm -f /tmp/jupyter_enterprise_gateway*.whl
+
+ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+ADD start-enterprise-gateway.sh.template /usr/local/share/jupyter
+
+# Massage kernelspecs to docker image env...
+# Create symbolic link to preserve hdp-related directories
+# Copy toree jar from install to scala kernelspec lib directory
+# Add YARN_CONF_DIR to each env stanza, Add PATH to R-yarn-client env stanza
+RUN mkdir -p /usr/hdp/current && \
+	ln -s /usr/local/spark-2.1.0-bin-hadoop2.7 /usr/hdp/current/spark2-client && \
+	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/lib && \
+	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib && \
+	cd /usr/local/share/jupyter/kernels && \
+	for dir in spark_2.1_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
+	cat spark_2.1_R_yarn_client/kernel.json | sed s/'"env": {'/'"env": {|    "PATH": "\/opt\/anaconda2\/bin:$PATH",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_2.1_R_yarn_client/kernel.json && \
+	touch /usr/local/share/jupyter/enterprise-gateway.log && \
+	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
+
+# Create service user 'elyra'. Pin uid/gid to 1111.  
+# Grant sudo privs to elyra. Unlock passwd (for ssh).
+# Add users 'bob' and 'alice' for test/demo purposes.
+# Add user 'jovyan' for compatibility with other Jupyter images.
+RUN adduser elyra -u 1111 -G users && \
+	echo "elyra ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/elyra && \
+	chmod 0440 /etc/sudoers.d/elyra && \
+	passwd -fu elyra && \
+	adduser bob -u 1112 -G users && \
+	adduser alice -u 1113 -G users && \
+	adduser jovyan -u 1000 -G users 
+
+USER elyra
+
+# passwordless ssh
+RUN ssh-keygen -q -N "" -t rsa -f /home/elyra/.ssh/id_rsa && \
+	cp /home/elyra/.ssh/id_rsa.pub /home/elyra/.ssh/authorized_keys && \
+	chmod 0700 /home/elyra
+
+USER root
+
+# install boot script 
+COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh
+RUN chown root.root /etc/bootstrap-enterprise-gateway.sh && \
+	chmod 0700 /etc/bootstrap-enterprise-gateway.sh
+
+WORKDIR /usr/local/share/jupyter 
+
+ENTRYPOINT ["/etc/bootstrap-enterprise-gateway.sh"]
+
+EXPOSE 8888

--- a/etc/docker/enterprise-gateway/README.md
+++ b/etc/docker/enterprise-gateway/README.md
@@ -1,0 +1,43 @@
+Built on [elyra/hadoop-spark](https://hub.docker.com/r/elyra/hadoop-spark/), this image adds support for [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) to better demonstrate running Python, R and Scala kernels in YARN-cluster mode.  It can also demonstrate invoking remote kernels via ssh (although in loopback) in YARN-client mode.
+
+# What it Gives You
+* [elyra/hadoop-spark](https://hub.docker.com/r/elyra/hadoop-spark/) base
+* [Jupyter Enterprise Gateway](https://github.com/jupyter-incubator/enterprise_gateway)
+* Python/R/Toree kernels that target both remote YARN-cluster and YARN-client modes (loopback)
+* `elyra` service user, with system users `jovyan`, `bob`, and `alice`.  The jovyan uid is `1000` to match other jupyter images.
+* Password-less ssh for service user
+* Users have HDFS folder setup at startup
+
+# Basic Use
+
+
+The following command can be used to start enterprise gateway ...
+
+`docker run -it --rm -p 8888:8888 -p 8088:8088 -p 8042:8042 --net=host elyra/enterprise-gateway:0.7.0.dev0 --elyra`
+
+To produce a general usage statement, the following can used...
+
+`docker run elyra/enterprise-gateway:0.7.0.dev0 --help`
+
+To run the enterprise-gateway container in an interactive mode, where enterprise gateway is manually started within the container, use the following...
+
+`docker run -it --rm -p 8888:8888 -p 8088:8088 -p 8042:8042 --net=host elyra/enterprise-gateway:0.7.0.dev0 bash`
+
+Once in the container, enterprise-gateway can be started using `/usr/local/share/jupyter/start-enterprise-gateway.sh`
+
+**Tip:** YARN logs can be accessed via host system's public IP on port `8042` rather than using container's `hostname:8042`, while YARN Resource manager can be accessed via container's `hostname:8088` port.
+
+# Recognized Environment Variables
+The following environment variables are recognized during startup of the container and can be specified via docker's `-e` option.  These will rarely need to be modified.
+
+`KG_IP`: specifies the IP address of enterprise gateway.  This should be a public IP.  Default = 0.0.0.0
+`KG_PORT`: specifies the port that enterprise gateway is listening on.  This port should be mapped to a host port via `-p`. Default = 8888
+`KG_PORT_RETRIES`: specifies the number of retries due to port conflicts that will be attempted.  Default = 0
+
+`EG_REMOTE_HOSTS`: specifies a comma-separated lists of hostnames which can be used to run YARN-client kernels.  Default = <container-hostname>
+`EG_YARN_ENDPOINT`: specifies the HTTP endpoint of the YARN Resource Manager.  Default = http://<hostname>:8088/ws/v1/cluster}
+`EG_SSH_PORT=`: specifies the port of the SSH server.  This container is setup to use port `2122`.  This value should not be changed.  Default = 2122
+
+`EG_ENABLE_TUNNELING`: specifies whether port tunneling will be used.  This value is currently `False` because ssh tunneling is 
+not working unless Enterprise Gateway is run as the root user.  This can be accomplished by starting the container with `bash` 
+as the command and running `start-enterprise-gateway.sh` directly (sans `sudo`).

--- a/etc/docker/enterprise-gateway/bootstrap-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/bootstrap-enterprise-gateway.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# This file is a copy of /etc/bootstrap.sh but invokes Jupyter Enterprise Gateway in its "deamon" case.
+# It also checks for --help or no options before starting anything...
+
+
+CMD=${1:-"--help"}
+if [[ "$CMD" == "--help" ]];
+then
+	echo ""
+	echo "usage: docker run -h <container-hostname> -p 8888:8888 -p 8088:8088 -p 8042:8042 <docker-opts> <docker-image> <command>"
+	echo ""
+	echo "where <command> is:"
+	echo "    --elyra ... Invokes Enterprise Gateway as user 'elyra' directly.  Useful for daemon behavior."
+	echo "    --help  ... Produces this message."
+	echo "    <other> ... Invokes '/bin/bash -c <other>'.  Use <other>='bash' to explore within the container."
+	echo ""
+	echo "NOTE: It is advised that port '8888' be mapped to a host port, although the host port number is not"
+	echo "      required to be '8888'.  Mapping of ports '8088' and '8042' is also strongly recommended"
+	echo "      for YARN application monitoring."
+	exit 0
+fi
+
+: ${HADOOP_PREFIX:=/usr/local/hadoop}
+
+$HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+
+rm /tmp/*.pid
+
+# installing libraries if any - (resource urls added comma separated to the ACP system variable)
+cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; curl -LO $cp ; done; cd -
+
+# altering the hostname in core-site and enterprise-gateway startup configuration
+sed s/HOSTNAME/$HOSTNAME/ /usr/local/hadoop/etc/hadoop/core-site.xml.template > /usr/local/hadoop/etc/hadoop/core-site.xml
+sed s/HOSTNAME/$HOSTNAME/ /usr/local/share/jupyter/start-enterprise-gateway.sh.template > /usr/local/share/jupyter/start-enterprise-gateway.sh
+chmod 0755 /usr/local/share/jupyter/start-enterprise-gateway.sh
+
+# setting spark defaults
+cp $SPARK_HOME/conf/spark-defaults.conf.template  $SPARK_HOME/conf/spark-defaults.conf
+
+cp $SPARK_HOME/conf/metrics.properties.template $SPARK_HOME/conf/metrics.properties
+
+service rsyslog start
+service rsyslog status
+service sshd start
+service sshd status
+$HADOOP_PREFIX/sbin/start-dfs.sh
+$HADOOP_PREFIX/sbin/start-yarn.sh
+
+# Add HDFS folders for our users (elyra, bob, alice)...
+echo "Waiting for Namenode to exit safemode..."
+hdfs dfsadmin -safemode wait
+echo "Setting up HDFS folders for Enterprise Gateway users..."
+hdfs dfs -mkdir -p /user/{elyra,bob,alice} /tmp/hive
+hdfs dfs -chown elyra:elyra /user/elyra
+hdfs dfs -chown bob:bob /user/bob
+hdfs dfs -chown alice:alice /user/alice
+hdfs dfs -chmod 0777 /tmp/hive
+
+
+CMD=${1:-"--help"}
+if [[ "$CMD" == "--elyra" ]];
+then
+	sudo -u elyra /usr/local/share/jupyter/start-enterprise-gateway.sh
+else
+	echo ""
+	echo "Note: Enterprise Gateway can be manually started using 'sudo -u elyra /usr/local/share/jupyter/start-enterprise-gateway.sh'..."
+	echo "      YARN application logs can be found at '/usr/local/hadoop-2.7.1/logs/userlogs'"
+	/bin/bash -c "$*"
+fi
+exit 0

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh.template
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh.template
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+export ANACONDA_HOME=/opt/anaconda2
+
+
+export JAVA_HOME=/usr/java/default
+
+export HADOOP_PREFIX=/usr/local/hadoop
+export HADOOP_HDFS_HOME=${HADOOP_PREFIX}
+export HADOOP_COMMON_HOME=${HADOOP_PREFIX}
+export HADOOP_YARN_HOME=${HADOOP_PREFIX}
+export HADOOP_MAPRED_HOME={HADOOP_PREFIX}
+export HADOOP_CONF_DIR=${HADOOP_PREFIX}/etc/hadoop
+export YARN_CONF_DIR={HADOOP_PREFIX}/etc/hadoop
+export SPARK_HOME=/usr/local/spark
+
+export PYSPARK_PYTHON=${ANACONDA_HOME}/bin/python
+export PATH=${ANACONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${JAVA_HOME}/bin:${SPARK_HOME}/bin:${HADOOP_PREFIX}/bin
+
+# Enterprise Gateway variables
+export EG_REMOTE_HOSTS=${EG_REMOTE_HOSTS:-HOSTNAME}
+export EG_YARN_ENDPOINT=${EG_YARN_ENDPOINT:-http://HOSTNAME:8088/ws/v1/cluster}
+export EG_SSH_PORT=${EG_SSH_PORT:-2122}
+export KG_IP=${KG_IP:-0.0.0.0}
+export KG_PORT=${KG_PORT:-8888}
+export KG_PORT_RETRIES=${KG_PORT_RETRIES:-0}
+
+# TODO: figure out why tunneling doesn't work from non-root user.
+# To use tunneling set this variable to 'True' and run as root.
+export EG_ENABLE_TUNNELING=${EG_ENABLE_TUNNELING:-False}
+
+echo "Starting Jupyter Enterprise Gateway..."
+
+jupyter enterprisegateway \
+	--log-level=DEBUG \
+	--MappingKernelManager.cull_idle_timeout=600 \
+	--MappingKernelManager.cull_interval=30 \
+	--MappingKernelManager.cull_connected=True 2>&1 | tee /usr/local/share/jupyter/enterprise-gateway.log
+
+

--- a/etc/docker/hadoop-spark/Dockerfile
+++ b/etc/docker/hadoop-spark/Dockerfile
@@ -1,0 +1,45 @@
+# Use docker image with Spark 2.1 and Hadoop 2.7 (sequenceiq/hadoop-docker:2.7.1)
+FROM aghorbani/spark:2.1.0
+
+ENV ANACONDA_HOME=/opt/anaconda2
+ENV PATH=$ANACONDA_HOME/bin:$PATH
+ENV PYSPARK_PYTHON=$ANACONDA_HOME/bin/python
+
+# Install system logging and insert into bootstrap.sh - helps in troubleshooting ssh
+RUN cd /tmp && \
+	curl -LO 'http://vault.centos.org/6.9/os/Source/SPackages/rsyslog-5.8.10-10.el6_6.src.rpm' && \
+	rpm -i /tmp/rsyslog-5.8.10-10.el6_6.src.rpm && \
+	rm -f /tmp/rsyslog-5.8.10-10.el6_6.src.rpm && \
+	RUN cat /etc/bootstrap.sh | sed s/'service sshd'/'service rsyslog start|service sshd'/ | tr '|' '\n' > /tmp/bootstrap.sh && \
+	mv /tmp/bootstrap.sh /etc && \
+	chmod 700 /etc/bootstrap.sh
+
+# Update Java
+RUN cd /tmp && \
+	curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jdk-8u151-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
+	rpm -e jdk-1.7.0_71-fcs.x86_64 && \
+	rpm -i /tmp/jdk-8u151-linux-x64.rpm && \
+	rm -f /tmp/jdk-8u151-linux-x64.rpm
+
+
+# Install Anaconda
+RUN cd /tmp && \
+	curl -O https://repo.continuum.io/archive/Anaconda2-4.4.0-Linux-x86_64.sh && \
+    bash /tmp/Anaconda2-4.4.0-Linux-x86_64.sh -b -p $ANACONDA_HOME && \
+    rm -f /tmp/Anaconda2-4.4.0-Linux-x86_64.sh
+
+# Install Toree
+RUN cd /tmp && \
+	curl -O https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc1/toree-pip/toree-0.2.0.tar.gz && \
+	pip install /tmp/toree-0.2.0.tar.gz && \
+	jupyter toree install --spark_home=/usr/local/spark --kernel_name="Spark 2.1" --interpreters=Scala && \
+	rm -f /tmp/toree-0.2.0.tar.gz
+
+# Install Anaconda R binaries, argparser and kernelspecs dir
+RUN conda install --yes --quiet -c r r-essentials r-irkernel && \
+	Rscript -e 'install.packages("argparser", repos="https://cran.rstudio.com")' 
+
+LABEL Hadoop.version="2.7.1"
+LABEL Spark.version="2.1.0"
+LABEL Anaconda.version="4.4.0"
+LABEL Anaconda.python.version="2.7.13"

--- a/etc/docker/hadoop-spark/README.md
+++ b/etc/docker/hadoop-spark/README.md
@@ -1,0 +1,8 @@
+Built on [aghorbani/spark:2.1.0](https://hub.docker.com/r/aghorbani/spark/) that includes [Hadoop](http://hadoop.apache.org/) (2.7.1) and [Spark](https://spark.apache.org/) (2.1.0), this image updates Java to 1.8 (jdk-8u151), and adds Anaconda (4.4 with R) and [Toree](https://toree.apache.org/) (0.2.0) to act as a base image for [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/). 
+
+# What it Gives You
+* Hadoop 2.7.1 
+* Spark 2.1.0
+* Java 1.8 (jdk-8u151)
+* Anaconda 4.4 (python 2.7.13) with R packages
+* Toree 0.2.0.rc1

--- a/etc/docker/nb2kg/Dockerfile
+++ b/etc/docker/nb2kg/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+FROM jupyter/minimal-notebook:fa77fe99579b
+
+# pip packages
+RUN pip install --upgrade pip
+RUN pip install setuptools --ignore-installed --upgrade
+
+# Do the pip installs as the unprivileged notebook user
+USER jovyan
+
+# Install dashboard layout and preview within Jupyter Notebook
+RUN pip install "git+https://github.com/jupyter/kernel_gateway_demos.git#egg=nb2kg&subdirectory=nb2kg" && \
+    jupyter serverextension enable --py nb2kg --sys-prefix
+
+ADD start-nb2kg.sh /usr/local/share/jupyter/
+
+# Run with remote kernel managers
+CMD ["/usr/local/share/jupyter/start-nb2kg.sh"]
+
+WORKDIR /home/jovyan/work

--- a/etc/docker/nb2kg/README.md
+++ b/etc/docker/nb2kg/README.md
@@ -1,0 +1,26 @@
+This image adds the current master branch commit from [jupyter/kernel_gateway_demos/nb2kg](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) on top of image [jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook) with tag [`fa77fe99579b`](https://github.com/jupyter/docker-stacks/commit/fa77fe99579b7bf79f6c6311e933c5118e0ec897).  It must continue to use that image tag until NB2KG's dependencies are expanded to include Notebook versions >= 5.0.0.
+
+The tag of the elyra/nb2kg image corresponds to the commit hash within the [juptyer/kernel_gateway_demos](https://github.com/jupyter/kernel_gateway_demos) repo.
+
+# What it Gives You
+This image is configured to be run against [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) instances, although running against Jupyter Kernel Gateway instances should be fine.
+
+# Basic Use
+If the gateway server is remote, the following command can be used to direct NB2KG to that gateway...
+
+`docker run -t --rm -p 8888:8888 -e GATEWAY_HOST=<gateway-hostname> -v <host-notebook-directory>:/home/jovyan/work elyra/nb2kg:<tag>`
+
+This will configure the `KG_URL` to `http://${GATEWAY_HOST}:8888` with KERNEL_USERNAME set to `jovyan`.
+
+# Alternative Uses
+If you have an `elyra/enterprise-gateway` container running on the same host, or would like to run mulitple notebook instances against the same gateway, the ports of the NB2KG can be adjusted as follows:
+
+`docker run -t --rm -p 9002:9002 -e NB_PORT=9002 -e GATEWAY_HOST=<gateway-hostname> -v <host-notebook-directory>:/home/jovyan/work elyra/nb2kg`
+
+This maps port `9002` of the container to host port `9002` and instructs the container to use `9002` as the notebook port. The use of `-e NB_PORT` is only necessary if running on the same host as the gateway server. If that's not the, then only `-p 9002:8888` is required to support multiple NB2KG instances on the same host.
+
+You can then run multiple notebook sessions on the same host by using different port mappings.  In addition, additional users can be emulated by setting the `KG_HTTP_USER` environment variable.
+
+`docker run -t --rm -p 9003:8888 -e GATEWAY_HOST=<gateway-hostname> -e KG_HTTP_USER=bob -v <host-notebook-directory>:/home/jovyan/work elyra/nb2kg`
+
+Here, the notebook will be available at port `9003` on the host and the `KERNEL_USERNAME` variable will be set to `bob`. Note that in this case, `-e NB_PORT` is not used since the gateway is not on the same host (in this example).

--- a/etc/docker/nb2kg/start-nb2kg.sh
+++ b/etc/docker/nb2kg/start-nb2kg.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+export NB_PORT=${NB_PORT:-8888}
+export GATEWAY_HOST=${GATEWAY_HOST:-localhost}
+export KG_URL=${KG_URL:-http://${GATEWAY_HOST}:8888}
+export KG_HTTP_USER=${KG_HTTP_USER:-jovyan}
+export KG_REQUEST_TIMEOUT=${KG_REQUEST_TIMEOUT:-30}
+export KERNEL_USERNAME=${KG_HTTP_USER}
+
+echo "Starting nb2kg against gateway: " ${KG_URL}
+echo "Nootbook port: " ${NB_PORT}
+echo "Kernel user: " ${KERNEL_USERNAME}
+
+jupyter notebook \
+  --NotebookApp.session_manager_class=nb2kg.managers.SessionManager \
+  --NotebookApp.kernel_manager_class=nb2kg.managers.RemoteKernelManager \
+  --NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager \
+  --no-browser \
+  --NotebookApp.port=${NB_PORT} \
+  --NotebookApp.ip=0.0.0.0


### PR DESCRIPTION
Created three docker directores under `etc/docker` to contain the files
necessary to build images.  The three directories are `hadoop-spark`,
`enterprise-gateway` and `nb2kg`. Each directory contains a `README.md`
describing how the image is to be used.

Updated the on-line docs with a docker section that is tied into the
developer workflow page.  The docker page contains descriptions of each
image with links to the docker and git hub repositories.

Cleanup Makefile - make `bdist` and `kernelspecs` targets dependent upon
the appropriate files - otherwise these targets would always run when no
changes were present.  Also made the new docker image targets dependent
upon their files - as well as any files built and added into the image.

Fixes #205