### PR TITLE
Add integration tests and run against docker container

### DIFF
--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -41,11 +41,12 @@ docker_images                  Build docker images
 docs                           Make HTML documentation
 env                            Make a dev environment
 install                        Make a conda env with dist/*.whl and dist/*.tar.gz installed
+itest                          Run integration tests against docker container
 kernelspecs                    Make a tar.gz file consisting of kernelspec files
 nuke                           Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 sdist                          Make a dist/*.tar.gz source distribution
-test                           Make a python3 test run
+test                           Run unit tests
 ```
 Some of the more useful commands are listed below.
 

--- a/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### If no print, will be execute_result otherwise stream"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "application_1502395407456_0041\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "u'1534387b-0664-4bf8-819a-1b41827871ba'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# DIFFERENT\n",
+    "print sc.applicationId\n",
+    "sc.appName"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import lib, define function/class, declare variables, will not return any message/output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy, os, sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test():\n",
+    "    print \"this is a test\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class Demo(object):\n",
+    "    def __init__(self):\n",
+    "        self.val = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "a = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Multi-output-type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is a test\n",
+      "this is a test\n",
+      "this is a test\n"
+     ]
+    }
+   ],
+   "source": [
+    "test()\n",
+    "test()\n",
+    "test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'2.1.1.2.6.1.0-129'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# DEPENDS\n",
+    "sc.version"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - Python (YARN Client Mode)",
+   "language": "python",
+   "name": "spark_2.1_python_yarn_client"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2.0
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### If no print, will be execute_result otherwise stream"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "application_1500314514041_0209\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "u'3aabd00c-1443-4918-b5fa-521f20edfd88'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# DIFFERENT\n",
+    "print sc.applicationId\n",
+    "sc.appName"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Import lib, define function/class, declare variables, will not return any message/output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy, os, sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test():\n",
+    "    print \"this is a test\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "class Demo(object):\n",
+    "    def __init__(self):\n",
+    "        self.val = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "a = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Multi-output-type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "this is a test\n",
+      "this is a test\n",
+      "this is a test\n"
+     ]
+    }
+   ],
+   "source": [
+    "test()\n",
+    "test()\n",
+    "test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'2.1.1.2.6.1.0-129'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# DEPENDS\n",
+    "sc.version"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+   "language": "python",
+   "name": "spark_2.1_python_yarn_cluster"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2.0
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/notebooks/R_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Client1.ipynb
@@ -1,0 +1,912 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use Spark for R to load data and run SQL queries\n",
+    "This notebook introduces basic Spark concepts and helps you to start using Spark for R.\n",
+    "\n",
+    "Some familiarity with R is recommended. This notebook runs on R with Spark 2.0.\n",
+    "\n",
+    "In this notebook, you'll use the publicly available **mtcars** data set from *Motor Trend* magazine to learn some basic R. You'll learn how to load data, create a Spark DataFrame, aggregate data, run mathematical formulas, and run SQL queries against the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table of contents\n",
+    "This notebook contains these main sections:\n",
+    "\n",
+    "1. [Load a DataFrame](#Load_a_DataFrame)\n",
+    "2. [Initialize an SQLContext](#Initialize_an_SQLContext)\n",
+    "3. [Create a Spark DataFrame](#Create_a_Spark_DataFrame)\n",
+    "4. [Aggregate data after grouping by columns](#Aggregate_data_after_grouping_by_columns)\n",
+    "5. [Operate on columns](#Operate_on_columns)\n",
+    "6. [Run SQL queries from the Spark DataFrame](#Run_SQL_queries_from_the_Spark_DataFrame)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Load_a_DataFrame'></a>\n",
+    "## 1. Load a DataFrame\n",
+    "A DataFrame is a distributed collection of data that is organized into named columns. The built-in R DataFrame called **mtcars** includes observations on the following 11 variables:\n",
+    "\n",
+    "`[, 1]\tmpg     Miles / (US) gallon`  \n",
+    "`[, 2]\tcyl     Number of cylinders`  \n",
+    "`[, 3]\tdisp\tDisplacement (cu. in.)`  \n",
+    "`[, 4]\thp      Gross horsepower`  \n",
+    "`[, 5]\tdrat    Rear axle ratio`  \n",
+    "`[, 6]\twt      Weight (1000 lbs)`  \n",
+    "`[, 7]\tqsec    1/4 mile time (seconds)`  \n",
+    "`[, 8]\tvs      0 = V-engine, 1 = straight engine`  \n",
+    "`[, 9]\tam      Transmission (0 = automatic, 1 = manual)`  \n",
+    "`[,10]\tgear    Number of forward gears`  \n",
+    "`[,11]\tcarb    Number of carburetors`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Preview the first 3 rows of the DataFrame by using the head() function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th></th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>Mazda RX4</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.620</td><td>16.46</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
+       "\t<tr><th scope=row>Mazda RX4 Wag</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.875</td><td>17.02</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
+       "\t<tr><th scope=row>Datsun 710</th><td>22.8 </td><td>4    </td><td>108  </td><td> 93  </td><td>3.85 </td><td>2.320</td><td>18.61</td><td>1    </td><td>1    </td><td>4    </td><td>1    </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|lllllllllll}\n",
+       "  & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
+       "\\hline\n",
+       "\tMazda RX4 & 21.0  & 6     & 160   & 110   & 3.90  & 2.620 & 16.46 & 0     & 1     & 4     & 4    \\\\\n",
+       "\tMazda RX4 Wag & 21.0  & 6     & 160   & 110   & 3.90  & 2.875 & 17.02 & 0     & 1     & 4     & 4    \\\\\n",
+       "\tDatsun 710 & 22.8  & 4     & 108   &  93   & 3.85  & 2.320 & 18.61 & 1     & 1     & 4     & 1    \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "| <!--/--> | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
+       "|---|---|---|\n",
+       "| Mazda RX4 | 21.0  | 6     | 160   | 110   | 3.90  | 2.620 | 16.46 | 0     | 1     | 4     | 4     | \n",
+       "| Mazda RX4 Wag | 21.0  | 6     | 160   | 110   | 3.90  | 2.875 | 17.02 | 0     | 1     | 4     | 4     | \n",
+       "| Datsun 710 | 22.8  | 4     | 108   |  93   | 3.85  | 2.320 | 18.61 | 1     | 1     | 4     | 1     | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "              mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
+       "Mazda RX4     21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
+       "Mazda RX4 Wag 21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
+       "Datsun 710    22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "# Since this display_data would be transformed into mark down of <table></table>\n",
+    "head(mtcars, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the car name data, which appears in the row names, into an actual column so that Spark can read it as a column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4        </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.620            </td><td>16.46            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag    </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.875            </td><td>17.02            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
+       "\t<tr><td>Datsun 710       </td><td>22.8             </td><td>4                </td><td>108              </td><td> 93              </td><td>3.85             </td><td>2.320            </td><td>18.61            </td><td>1                </td><td>1                </td><td>4                </td><td>1                </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive   </td><td>21.4             </td><td>6                </td><td>258              </td><td>110              </td><td>3.08             </td><td>3.215            </td><td>19.44            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout</td><td>18.7             </td><td>8                </td><td>360              </td><td>175              </td><td>3.15             </td><td>3.440            </td><td>17.02            </td><td>0                </td><td>0                </td><td>3                </td><td>2                </td></tr>\n",
+       "\t<tr><td>Valiant          </td><td>18.1             </td><td>6                </td><td>225              </td><td>105              </td><td>2.76             </td><td>3.460            </td><td>20.22            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|llllllllllll}\n",
+       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
+       "\\hline\n",
+       "\t Mazda RX4         & 21.0              & 6                 & 160               & 110               & 3.90              & 2.620             & 16.46             & 0                 & 1                 & 4                 & 4                \\\\\n",
+       "\t Mazda RX4 Wag     & 21.0              & 6                 & 160               & 110               & 3.90              & 2.875             & 17.02             & 0                 & 1                 & 4                 & 4                \\\\\n",
+       "\t Datsun 710        & 22.8              & 4                 & 108               &  93               & 3.85              & 2.320             & 18.61             & 1                 & 1                 & 4                 & 1                \\\\\n",
+       "\t Hornet 4 Drive    & 21.4              & 6                 & 258               & 110               & 3.08              & 3.215             & 19.44             & 1                 & 0                 & 3                 & 1                \\\\\n",
+       "\t Hornet Sportabout & 18.7              & 8                 & 360               & 175               & 3.15              & 3.440             & 17.02             & 0                 & 0                 & 3                 & 2                \\\\\n",
+       "\t Valiant           & 18.1              & 6                 & 225               & 105               & 2.76              & 3.460             & 20.22             & 1                 & 0                 & 3                 & 1                \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
+       "|---|---|---|---|---|---|\n",
+       "| Mazda RX4         | 21.0              | 6                 | 160               | 110               | 3.90              | 2.620             | 16.46             | 0                 | 1                 | 4                 | 4                 | \n",
+       "| Mazda RX4 Wag     | 21.0              | 6                 | 160               | 110               | 3.90              | 2.875             | 17.02             | 0                 | 1                 | 4                 | 4                 | \n",
+       "| Datsun 710        | 22.8              | 4                 | 108               |  93               | 3.85              | 2.320             | 18.61             | 1                 | 1                 | 4                 | 1                 | \n",
+       "| Hornet 4 Drive    | 21.4              | 6                 | 258               | 110               | 3.08              | 3.215             | 19.44             | 1                 | 0                 | 3                 | 1                 | \n",
+       "| Hornet Sportabout | 18.7              | 8                 | 360               | 175               | 3.15              | 3.440             | 17.02             | 0                 | 0                 | 3                 | 2                 | \n",
+       "| Valiant           | 18.1              | 6                 | 225               | 105               | 2.76              | 3.460             | 20.22             | 1                 | 0                 | 3                 | 1                 | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  car               mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
+       "1 Mazda RX4         21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
+       "2 Mazda RX4 Wag     21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
+       "3 Datsun 710        22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   \n",
+       "4 Hornet 4 Drive    21.4 6   258  110 3.08 3.215 19.44 1  0  3    1   \n",
+       "5 Hornet Sportabout 18.7 8   360  175 3.15 3.440 17.02 0  0  3    2   \n",
+       "6 Valiant           18.1 6   225  105 2.76 3.460 20.22 1  0  3    1   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "mtcars$car <- rownames(mtcars)\n",
+    "mtcars <- mtcars[,c(12,1:11)]\n",
+    "rownames(mtcars) <- 1:nrow(mtcars)\n",
+    "head(mtcars)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Initialize_an_SQLContext'></a>\n",
+    "## 2. Initialize an SQLContext\n",
+    "To work with a DataFrame, you need an SQLContext. You create this SQLContext by using `sparkRSQL.init(sc)`. A SparkContext named sc, which has been created for you, is used to initialize the SQLContext:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sqlContext <- sparkR.session(sc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Create_a_Spark_DataFrame'></a>\n",
+    "## 3. Create a Spark DataFrame\n",
+    "Using the SQLContext and the loaded local DataFrame, create a Spark DataFrame and print the schema, or structure, of the DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- car: string (nullable = true)\n",
+      " |-- mpg: double (nullable = true)\n",
+      " |-- cyl: double (nullable = true)\n",
+      " |-- disp: double (nullable = true)\n",
+      " |-- hp: double (nullable = true)\n",
+      " |-- drat: double (nullable = true)\n",
+      " |-- wt: double (nullable = true)\n",
+      " |-- qsec: double (nullable = true)\n",
+      " |-- vs: double (nullable = true)\n",
+      " |-- am: double (nullable = true)\n",
+      " |-- gear: double (nullable = true)\n",
+      " |-- carb: double (nullable = true)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sdf <- createDataFrame(mtcars, schema = NULL) \n",
+    "printSchema(sdf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the content of the Spark DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4          </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.620              </td><td>16.46              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag      </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.875              </td><td>17.02              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Datsun 710         </td><td>22.8               </td><td>4                  </td><td>108.0              </td><td> 93                </td><td>3.85               </td><td>2.320              </td><td>18.61              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive     </td><td>21.4               </td><td>6                  </td><td>258.0              </td><td>110                </td><td>3.08               </td><td>3.215              </td><td>19.44              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout  </td><td>18.7               </td><td>8                  </td><td>360.0              </td><td>175                </td><td>3.15               </td><td>3.440              </td><td>17.02              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Valiant            </td><td>18.1               </td><td>6                  </td><td>225.0              </td><td>105                </td><td>2.76               </td><td>3.460              </td><td>20.22              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Duster 360         </td><td>14.3               </td><td>8                  </td><td>360.0              </td><td>245                </td><td>3.21               </td><td>3.570              </td><td>15.84              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 240D          </td><td>24.4               </td><td>4                  </td><td>146.7              </td><td> 62                </td><td>3.69               </td><td>3.190              </td><td>20.00              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Merc 230           </td><td>22.8               </td><td>4                  </td><td>140.8              </td><td> 95                </td><td>3.92               </td><td>3.150              </td><td>22.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Merc 280           </td><td>19.2               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.30              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 280C          </td><td>17.8               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 450SE         </td><td>16.4               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>4.070              </td><td>17.40              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Merc 450SL         </td><td>17.3               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.730              </td><td>17.60              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Merc 450SLC        </td><td>15.2               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.780              </td><td>18.00              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Cadillac Fleetwood </td><td>10.4               </td><td>8                  </td><td>472.0              </td><td>205                </td><td>2.93               </td><td>5.250              </td><td>17.98              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Lincoln Continental</td><td>10.4               </td><td>8                  </td><td>460.0              </td><td>215                </td><td>3.00               </td><td>5.424              </td><td>17.82              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Chrysler Imperial  </td><td>14.7               </td><td>8                  </td><td>440.0              </td><td>230                </td><td>3.23               </td><td>5.345              </td><td>17.42              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Fiat 128           </td><td>32.4               </td><td>4                  </td><td> 78.7              </td><td> 66                </td><td>4.08               </td><td>2.200              </td><td>19.47              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Honda Civic        </td><td>30.4               </td><td>4                  </td><td> 75.7              </td><td> 52                </td><td>4.93               </td><td>1.615              </td><td>18.52              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Toyota Corolla     </td><td>33.9               </td><td>4                  </td><td> 71.1              </td><td> 65                </td><td>4.22               </td><td>1.835              </td><td>19.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Toyota Corona      </td><td>21.5               </td><td>4                  </td><td>120.1              </td><td> 97                </td><td>3.70               </td><td>2.465              </td><td>20.01              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Dodge Challenger   </td><td>15.5               </td><td>8                  </td><td>318.0              </td><td>150                </td><td>2.76               </td><td>3.520              </td><td>16.87              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>AMC Javelin        </td><td>15.2               </td><td>8                  </td><td>304.0              </td><td>150                </td><td>3.15               </td><td>3.435              </td><td>17.30              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Camaro Z28         </td><td>13.3               </td><td>8                  </td><td>350.0              </td><td>245                </td><td>3.73               </td><td>3.840              </td><td>15.41              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Pontiac Firebird   </td><td>19.2               </td><td>8                  </td><td>400.0              </td><td>175                </td><td>3.08               </td><td>3.845              </td><td>17.05              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Fiat X1-9          </td><td>27.3               </td><td>4                  </td><td> 79.0              </td><td> 66                </td><td>4.08               </td><td>1.935              </td><td>18.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Porsche 914-2      </td><td>26.0               </td><td>4                  </td><td>120.3              </td><td> 91                </td><td>4.43               </td><td>2.140              </td><td>16.70              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Lotus Europa       </td><td>30.4               </td><td>4                  </td><td> 95.1              </td><td>113                </td><td>3.77               </td><td>1.513              </td><td>16.90              </td><td>1                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Ford Pantera L     </td><td>15.8               </td><td>8                  </td><td>351.0              </td><td>264                </td><td>4.22               </td><td>3.170              </td><td>14.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Ferrari Dino       </td><td>19.7               </td><td>6                  </td><td>145.0              </td><td>175                </td><td>3.62               </td><td>2.770              </td><td>15.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>6                  </td></tr>\n",
+       "\t<tr><td>Maserati Bora      </td><td>15.0               </td><td>8                  </td><td>301.0              </td><td>335                </td><td>3.54               </td><td>3.570              </td><td>14.60              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>8                  </td></tr>\n",
+       "\t<tr><td>Volvo 142E         </td><td>21.4               </td><td>4                  </td><td>121.0              </td><td>109                </td><td>4.11               </td><td>2.780              </td><td>18.60              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|llllllllllll}\n",
+       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
+       "\\hline\n",
+       "\t Mazda RX4           & 21.0                & 6                   & 160.0               & 110                 & 3.90                & 2.620               & 16.46               & 0                   & 1                   & 4                   & 4                  \\\\\n",
+       "\t Mazda RX4 Wag       & 21.0                & 6                   & 160.0               & 110                 & 3.90                & 2.875               & 17.02               & 0                   & 1                   & 4                   & 4                  \\\\\n",
+       "\t Datsun 710          & 22.8                & 4                   & 108.0               &  93                 & 3.85                & 2.320               & 18.61               & 1                   & 1                   & 4                   & 1                  \\\\\n",
+       "\t Hornet 4 Drive      & 21.4                & 6                   & 258.0               & 110                 & 3.08                & 3.215               & 19.44               & 1                   & 0                   & 3                   & 1                  \\\\\n",
+       "\t Hornet Sportabout   & 18.7                & 8                   & 360.0               & 175                 & 3.15                & 3.440               & 17.02               & 0                   & 0                   & 3                   & 2                  \\\\\n",
+       "\t Valiant             & 18.1                & 6                   & 225.0               & 105                 & 2.76                & 3.460               & 20.22               & 1                   & 0                   & 3                   & 1                  \\\\\n",
+       "\t Duster 360          & 14.3                & 8                   & 360.0               & 245                 & 3.21                & 3.570               & 15.84               & 0                   & 0                   & 3                   & 4                  \\\\\n",
+       "\t Merc 240D           & 24.4                & 4                   & 146.7               &  62                 & 3.69                & 3.190               & 20.00               & 1                   & 0                   & 4                   & 2                  \\\\\n",
+       "\t Merc 230            & 22.8                & 4                   & 140.8               &  95                 & 3.92                & 3.150               & 22.90               & 1                   & 0                   & 4                   & 2                  \\\\\n",
+       "\t Merc 280            & 19.2                & 6                   & 167.6               & 123                 & 3.92                & 3.440               & 18.30               & 1                   & 0                   & 4                   & 4                  \\\\\n",
+       "\t Merc 280C           & 17.8                & 6                   & 167.6               & 123                 & 3.92                & 3.440               & 18.90               & 1                   & 0                   & 4                   & 4                  \\\\\n",
+       "\t Merc 450SE          & 16.4                & 8                   & 275.8               & 180                 & 3.07                & 4.070               & 17.40               & 0                   & 0                   & 3                   & 3                  \\\\\n",
+       "\t Merc 450SL          & 17.3                & 8                   & 275.8               & 180                 & 3.07                & 3.730               & 17.60               & 0                   & 0                   & 3                   & 3                  \\\\\n",
+       "\t Merc 450SLC         & 15.2                & 8                   & 275.8               & 180                 & 3.07                & 3.780               & 18.00               & 0                   & 0                   & 3                   & 3                  \\\\\n",
+       "\t Cadillac Fleetwood  & 10.4                & 8                   & 472.0               & 205                 & 2.93                & 5.250               & 17.98               & 0                   & 0                   & 3                   & 4                  \\\\\n",
+       "\t Lincoln Continental & 10.4                & 8                   & 460.0               & 215                 & 3.00                & 5.424               & 17.82               & 0                   & 0                   & 3                   & 4                  \\\\\n",
+       "\t Chrysler Imperial   & 14.7                & 8                   & 440.0               & 230                 & 3.23                & 5.345               & 17.42               & 0                   & 0                   & 3                   & 4                  \\\\\n",
+       "\t Fiat 128            & 32.4                & 4                   &  78.7               &  66                 & 4.08                & 2.200               & 19.47               & 1                   & 1                   & 4                   & 1                  \\\\\n",
+       "\t Honda Civic         & 30.4                & 4                   &  75.7               &  52                 & 4.93                & 1.615               & 18.52               & 1                   & 1                   & 4                   & 2                  \\\\\n",
+       "\t Toyota Corolla      & 33.9                & 4                   &  71.1               &  65                 & 4.22                & 1.835               & 19.90               & 1                   & 1                   & 4                   & 1                  \\\\\n",
+       "\t Toyota Corona       & 21.5                & 4                   & 120.1               &  97                 & 3.70                & 2.465               & 20.01               & 1                   & 0                   & 3                   & 1                  \\\\\n",
+       "\t Dodge Challenger    & 15.5                & 8                   & 318.0               & 150                 & 2.76                & 3.520               & 16.87               & 0                   & 0                   & 3                   & 2                  \\\\\n",
+       "\t AMC Javelin         & 15.2                & 8                   & 304.0               & 150                 & 3.15                & 3.435               & 17.30               & 0                   & 0                   & 3                   & 2                  \\\\\n",
+       "\t Camaro Z28          & 13.3                & 8                   & 350.0               & 245                 & 3.73                & 3.840               & 15.41               & 0                   & 0                   & 3                   & 4                  \\\\\n",
+       "\t Pontiac Firebird    & 19.2                & 8                   & 400.0               & 175                 & 3.08                & 3.845               & 17.05               & 0                   & 0                   & 3                   & 2                  \\\\\n",
+       "\t Fiat X1-9           & 27.3                & 4                   &  79.0               &  66                 & 4.08                & 1.935               & 18.90               & 1                   & 1                   & 4                   & 1                  \\\\\n",
+       "\t Porsche 914-2       & 26.0                & 4                   & 120.3               &  91                 & 4.43                & 2.140               & 16.70               & 0                   & 1                   & 5                   & 2                  \\\\\n",
+       "\t Lotus Europa        & 30.4                & 4                   &  95.1               & 113                 & 3.77                & 1.513               & 16.90               & 1                   & 1                   & 5                   & 2                  \\\\\n",
+       "\t Ford Pantera L      & 15.8                & 8                   & 351.0               & 264                 & 4.22                & 3.170               & 14.50               & 0                   & 1                   & 5                   & 4                  \\\\\n",
+       "\t Ferrari Dino        & 19.7                & 6                   & 145.0               & 175                 & 3.62                & 2.770               & 15.50               & 0                   & 1                   & 5                   & 6                  \\\\\n",
+       "\t Maserati Bora       & 15.0                & 8                   & 301.0               & 335                 & 3.54                & 3.570               & 14.60               & 0                   & 1                   & 5                   & 8                  \\\\\n",
+       "\t Volvo 142E          & 21.4                & 4                   & 121.0               & 109                 & 4.11                & 2.780               & 18.60               & 1                   & 1                   & 4                   & 2                  \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
+       "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n",
+       "| Mazda RX4           | 21.0                | 6                   | 160.0               | 110                 | 3.90                | 2.620               | 16.46               | 0                   | 1                   | 4                   | 4                   | \n",
+       "| Mazda RX4 Wag       | 21.0                | 6                   | 160.0               | 110                 | 3.90                | 2.875               | 17.02               | 0                   | 1                   | 4                   | 4                   | \n",
+       "| Datsun 710          | 22.8                | 4                   | 108.0               |  93                 | 3.85                | 2.320               | 18.61               | 1                   | 1                   | 4                   | 1                   | \n",
+       "| Hornet 4 Drive      | 21.4                | 6                   | 258.0               | 110                 | 3.08                | 3.215               | 19.44               | 1                   | 0                   | 3                   | 1                   | \n",
+       "| Hornet Sportabout   | 18.7                | 8                   | 360.0               | 175                 | 3.15                | 3.440               | 17.02               | 0                   | 0                   | 3                   | 2                   | \n",
+       "| Valiant             | 18.1                | 6                   | 225.0               | 105                 | 2.76                | 3.460               | 20.22               | 1                   | 0                   | 3                   | 1                   | \n",
+       "| Duster 360          | 14.3                | 8                   | 360.0               | 245                 | 3.21                | 3.570               | 15.84               | 0                   | 0                   | 3                   | 4                   | \n",
+       "| Merc 240D           | 24.4                | 4                   | 146.7               |  62                 | 3.69                | 3.190               | 20.00               | 1                   | 0                   | 4                   | 2                   | \n",
+       "| Merc 230            | 22.8                | 4                   | 140.8               |  95                 | 3.92                | 3.150               | 22.90               | 1                   | 0                   | 4                   | 2                   | \n",
+       "| Merc 280            | 19.2                | 6                   | 167.6               | 123                 | 3.92                | 3.440               | 18.30               | 1                   | 0                   | 4                   | 4                   | \n",
+       "| Merc 280C           | 17.8                | 6                   | 167.6               | 123                 | 3.92                | 3.440               | 18.90               | 1                   | 0                   | 4                   | 4                   | \n",
+       "| Merc 450SE          | 16.4                | 8                   | 275.8               | 180                 | 3.07                | 4.070               | 17.40               | 0                   | 0                   | 3                   | 3                   | \n",
+       "| Merc 450SL          | 17.3                | 8                   | 275.8               | 180                 | 3.07                | 3.730               | 17.60               | 0                   | 0                   | 3                   | 3                   | \n",
+       "| Merc 450SLC         | 15.2                | 8                   | 275.8               | 180                 | 3.07                | 3.780               | 18.00               | 0                   | 0                   | 3                   | 3                   | \n",
+       "| Cadillac Fleetwood  | 10.4                | 8                   | 472.0               | 205                 | 2.93                | 5.250               | 17.98               | 0                   | 0                   | 3                   | 4                   | \n",
+       "| Lincoln Continental | 10.4                | 8                   | 460.0               | 215                 | 3.00                | 5.424               | 17.82               | 0                   | 0                   | 3                   | 4                   | \n",
+       "| Chrysler Imperial   | 14.7                | 8                   | 440.0               | 230                 | 3.23                | 5.345               | 17.42               | 0                   | 0                   | 3                   | 4                   | \n",
+       "| Fiat 128            | 32.4                | 4                   |  78.7               |  66                 | 4.08                | 2.200               | 19.47               | 1                   | 1                   | 4                   | 1                   | \n",
+       "| Honda Civic         | 30.4                | 4                   |  75.7               |  52                 | 4.93                | 1.615               | 18.52               | 1                   | 1                   | 4                   | 2                   | \n",
+       "| Toyota Corolla      | 33.9                | 4                   |  71.1               |  65                 | 4.22                | 1.835               | 19.90               | 1                   | 1                   | 4                   | 1                   | \n",
+       "| Toyota Corona       | 21.5                | 4                   | 120.1               |  97                 | 3.70                | 2.465               | 20.01               | 1                   | 0                   | 3                   | 1                   | \n",
+       "| Dodge Challenger    | 15.5                | 8                   | 318.0               | 150                 | 2.76                | 3.520               | 16.87               | 0                   | 0                   | 3                   | 2                   | \n",
+       "| AMC Javelin         | 15.2                | 8                   | 304.0               | 150                 | 3.15                | 3.435               | 17.30               | 0                   | 0                   | 3                   | 2                   | \n",
+       "| Camaro Z28          | 13.3                | 8                   | 350.0               | 245                 | 3.73                | 3.840               | 15.41               | 0                   | 0                   | 3                   | 4                   | \n",
+       "| Pontiac Firebird    | 19.2                | 8                   | 400.0               | 175                 | 3.08                | 3.845               | 17.05               | 0                   | 0                   | 3                   | 2                   | \n",
+       "| Fiat X1-9           | 27.3                | 4                   |  79.0               |  66                 | 4.08                | 1.935               | 18.90               | 1                   | 1                   | 4                   | 1                   | \n",
+       "| Porsche 914-2       | 26.0                | 4                   | 120.3               |  91                 | 4.43                | 2.140               | 16.70               | 0                   | 1                   | 5                   | 2                   | \n",
+       "| Lotus Europa        | 30.4                | 4                   |  95.1               | 113                 | 3.77                | 1.513               | 16.90               | 1                   | 1                   | 5                   | 2                   | \n",
+       "| Ford Pantera L      | 15.8                | 8                   | 351.0               | 264                 | 4.22                | 3.170               | 14.50               | 0                   | 1                   | 5                   | 4                   | \n",
+       "| Ferrari Dino        | 19.7                | 6                   | 145.0               | 175                 | 3.62                | 2.770               | 15.50               | 0                   | 1                   | 5                   | 6                   | \n",
+       "| Maserati Bora       | 15.0                | 8                   | 301.0               | 335                 | 3.54                | 3.570               | 14.60               | 0                   | 1                   | 5                   | 8                   | \n",
+       "| Volvo 142E          | 21.4                | 4                   | 121.0               | 109                 | 4.11                | 2.780               | 18.60               | 1                   | 1                   | 4                   | 2                   | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "   car                 mpg  cyl disp  hp  drat wt    qsec  vs am gear carb\n",
+       "1  Mazda RX4           21.0 6   160.0 110 3.90 2.620 16.46 0  1  4    4   \n",
+       "2  Mazda RX4 Wag       21.0 6   160.0 110 3.90 2.875 17.02 0  1  4    4   \n",
+       "3  Datsun 710          22.8 4   108.0  93 3.85 2.320 18.61 1  1  4    1   \n",
+       "4  Hornet 4 Drive      21.4 6   258.0 110 3.08 3.215 19.44 1  0  3    1   \n",
+       "5  Hornet Sportabout   18.7 8   360.0 175 3.15 3.440 17.02 0  0  3    2   \n",
+       "6  Valiant             18.1 6   225.0 105 2.76 3.460 20.22 1  0  3    1   \n",
+       "7  Duster 360          14.3 8   360.0 245 3.21 3.570 15.84 0  0  3    4   \n",
+       "8  Merc 240D           24.4 4   146.7  62 3.69 3.190 20.00 1  0  4    2   \n",
+       "9  Merc 230            22.8 4   140.8  95 3.92 3.150 22.90 1  0  4    2   \n",
+       "10 Merc 280            19.2 6   167.6 123 3.92 3.440 18.30 1  0  4    4   \n",
+       "11 Merc 280C           17.8 6   167.6 123 3.92 3.440 18.90 1  0  4    4   \n",
+       "12 Merc 450SE          16.4 8   275.8 180 3.07 4.070 17.40 0  0  3    3   \n",
+       "13 Merc 450SL          17.3 8   275.8 180 3.07 3.730 17.60 0  0  3    3   \n",
+       "14 Merc 450SLC         15.2 8   275.8 180 3.07 3.780 18.00 0  0  3    3   \n",
+       "15 Cadillac Fleetwood  10.4 8   472.0 205 2.93 5.250 17.98 0  0  3    4   \n",
+       "16 Lincoln Continental 10.4 8   460.0 215 3.00 5.424 17.82 0  0  3    4   \n",
+       "17 Chrysler Imperial   14.7 8   440.0 230 3.23 5.345 17.42 0  0  3    4   \n",
+       "18 Fiat 128            32.4 4    78.7  66 4.08 2.200 19.47 1  1  4    1   \n",
+       "19 Honda Civic         30.4 4    75.7  52 4.93 1.615 18.52 1  1  4    2   \n",
+       "20 Toyota Corolla      33.9 4    71.1  65 4.22 1.835 19.90 1  1  4    1   \n",
+       "21 Toyota Corona       21.5 4   120.1  97 3.70 2.465 20.01 1  0  3    1   \n",
+       "22 Dodge Challenger    15.5 8   318.0 150 2.76 3.520 16.87 0  0  3    2   \n",
+       "23 AMC Javelin         15.2 8   304.0 150 3.15 3.435 17.30 0  0  3    2   \n",
+       "24 Camaro Z28          13.3 8   350.0 245 3.73 3.840 15.41 0  0  3    4   \n",
+       "25 Pontiac Firebird    19.2 8   400.0 175 3.08 3.845 17.05 0  0  3    2   \n",
+       "26 Fiat X1-9           27.3 4    79.0  66 4.08 1.935 18.90 1  1  4    1   \n",
+       "27 Porsche 914-2       26.0 4   120.3  91 4.43 2.140 16.70 0  1  5    2   \n",
+       "28 Lotus Europa        30.4 4    95.1 113 3.77 1.513 16.90 1  1  5    2   \n",
+       "29 Ford Pantera L      15.8 8   351.0 264 4.22 3.170 14.50 0  1  5    4   \n",
+       "30 Ferrari Dino        19.7 6   145.0 175 3.62 2.770 15.50 0  1  5    6   \n",
+       "31 Maserati Bora       15.0 8   301.0 335 3.54 3.570 14.60 0  1  5    8   \n",
+       "32 Volvo 142E          21.4 4   121.0 109 4.11 2.780 18.60 1  1  4    2   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(sdf, 32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try different ways of retrieving subsets of the data. For example, get the first 5 values in the **mpg** column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>mpg</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>21.0</td></tr>\n",
+       "\t<tr><td>21.0</td></tr>\n",
+       "\t<tr><td>22.8</td></tr>\n",
+       "\t<tr><td>21.4</td></tr>\n",
+       "\t<tr><td>18.7</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|l}\n",
+       " mpg\\\\\n",
+       "\\hline\n",
+       "\t 21.0\\\\\n",
+       "\t 21.0\\\\\n",
+       "\t 22.8\\\\\n",
+       "\t 21.4\\\\\n",
+       "\t 18.7\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "mpg | \n",
+       "|---|---|---|---|---|\n",
+       "| 21.0 | \n",
+       "| 21.0 | \n",
+       "| 22.8 | \n",
+       "| 21.4 | \n",
+       "| 18.7 | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  mpg \n",
+       "1 21.0\n",
+       "2 21.0\n",
+       "3 22.8\n",
+       "4 21.4\n",
+       "5 18.7"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(select(sdf, sdf$mpg),5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filter the DataFrame to retain only rows with **mpg** values that are less than 18:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Duster 360        </td><td>14.3              </td><td>8                 </td><td>360.0             </td><td>245               </td><td>3.21              </td><td>3.57              </td><td>15.84             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
+       "\t<tr><td>Merc 280C         </td><td>17.8              </td><td>6                 </td><td>167.6             </td><td>123               </td><td>3.92              </td><td>3.44              </td><td>18.90             </td><td>1                 </td><td>0                 </td><td>4                 </td><td>4                 </td></tr>\n",
+       "\t<tr><td>Merc 450SE        </td><td>16.4              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>4.07              </td><td>17.40             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Merc 450SL        </td><td>17.3              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.73              </td><td>17.60             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Merc 450SLC       </td><td>15.2              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.78              </td><td>18.00             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Cadillac Fleetwood</td><td>10.4              </td><td>8                 </td><td>472.0             </td><td>205               </td><td>2.93              </td><td>5.25              </td><td>17.98             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|llllllllllll}\n",
+       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
+       "\\hline\n",
+       "\t Duster 360         & 14.3               & 8                  & 360.0              & 245                & 3.21               & 3.57               & 15.84              & 0                  & 0                  & 3                  & 4                 \\\\\n",
+       "\t Merc 280C          & 17.8               & 6                  & 167.6              & 123                & 3.92               & 3.44               & 18.90              & 1                  & 0                  & 4                  & 4                 \\\\\n",
+       "\t Merc 450SE         & 16.4               & 8                  & 275.8              & 180                & 3.07               & 4.07               & 17.40              & 0                  & 0                  & 3                  & 3                 \\\\\n",
+       "\t Merc 450SL         & 17.3               & 8                  & 275.8              & 180                & 3.07               & 3.73               & 17.60              & 0                  & 0                  & 3                  & 3                 \\\\\n",
+       "\t Merc 450SLC        & 15.2               & 8                  & 275.8              & 180                & 3.07               & 3.78               & 18.00              & 0                  & 0                  & 3                  & 3                 \\\\\n",
+       "\t Cadillac Fleetwood & 10.4               & 8                  & 472.0              & 205                & 2.93               & 5.25               & 17.98              & 0                  & 0                  & 3                  & 4                 \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
+       "|---|---|---|---|---|---|\n",
+       "| Duster 360         | 14.3               | 8                  | 360.0              | 245                | 3.21               | 3.57               | 15.84              | 0                  | 0                  | 3                  | 4                  | \n",
+       "| Merc 280C          | 17.8               | 6                  | 167.6              | 123                | 3.92               | 3.44               | 18.90              | 1                  | 0                  | 4                  | 4                  | \n",
+       "| Merc 450SE         | 16.4               | 8                  | 275.8              | 180                | 3.07               | 4.07               | 17.40              | 0                  | 0                  | 3                  | 3                  | \n",
+       "| Merc 450SL         | 17.3               | 8                  | 275.8              | 180                | 3.07               | 3.73               | 17.60              | 0                  | 0                  | 3                  | 3                  | \n",
+       "| Merc 450SLC        | 15.2               | 8                  | 275.8              | 180                | 3.07               | 3.78               | 18.00              | 0                  | 0                  | 3                  | 3                  | \n",
+       "| Cadillac Fleetwood | 10.4               | 8                  | 472.0              | 205                | 2.93               | 5.25               | 17.98              | 0                  | 0                  | 3                  | 4                  | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  car                mpg  cyl disp  hp  drat wt   qsec  vs am gear carb\n",
+       "1 Duster 360         14.3 8   360.0 245 3.21 3.57 15.84 0  0  3    4   \n",
+       "2 Merc 280C          17.8 6   167.6 123 3.92 3.44 18.90 1  0  4    4   \n",
+       "3 Merc 450SE         16.4 8   275.8 180 3.07 4.07 17.40 0  0  3    3   \n",
+       "4 Merc 450SL         17.3 8   275.8 180 3.07 3.73 17.60 0  0  3    3   \n",
+       "5 Merc 450SLC        15.2 8   275.8 180 3.07 3.78 18.00 0  0  3    3   \n",
+       "6 Cadillac Fleetwood 10.4 8   472.0 205 2.93 5.25 17.98 0  0  3    4   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(SparkR::filter(sdf, sdf$mpg < 18))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Aggregate_data_after_grouping_by_columns'></a>\n",
+    "## 4. Aggregate data after grouping by columns\n",
+    "Spark DataFrames support a number of common functions to aggregate data after grouping. For example, you can compute the average weight of cars as a function of the number of cylinders:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>cyl</th><th scope=col>wtavg</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>8       </td><td>3.999214</td></tr>\n",
+       "\t<tr><td>4       </td><td>2.285727</td></tr>\n",
+       "\t<tr><td>6       </td><td>3.117143</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|ll}\n",
+       " cyl & wtavg\\\\\n",
+       "\\hline\n",
+       "\t 8        & 3.999214\\\\\n",
+       "\t 4        & 2.285727\\\\\n",
+       "\t 6        & 3.117143\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "cyl | wtavg | \n",
+       "|---|---|---|\n",
+       "| 8        | 3.999214 | \n",
+       "| 4        | 2.285727 | \n",
+       "| 6        | 3.117143 | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  cyl wtavg   \n",
+       "1 8   3.999214\n",
+       "2 4   2.285727\n",
+       "3 6   3.117143"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(summarize(groupBy(sdf, sdf$cyl), wtavg = avg(sdf$wt)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also sort the output from the aggregation to determine the most popular cylinder configuration in the DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>cyl</th><th scope=col>count</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>8 </td><td>14</td></tr>\n",
+       "\t<tr><td>4 </td><td>11</td></tr>\n",
+       "\t<tr><td>6 </td><td> 7</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|ll}\n",
+       " cyl & count\\\\\n",
+       "\\hline\n",
+       "\t 8  & 14\\\\\n",
+       "\t 4  & 11\\\\\n",
+       "\t 6  &  7\\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "cyl | count | \n",
+       "|---|---|---|\n",
+       "| 8  | 14 | \n",
+       "| 4  | 11 | \n",
+       "| 6  |  7 | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  cyl count\n",
+       "1 8   14   \n",
+       "2 4   11   \n",
+       "3 6    7   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "car_counts <-summarize(groupBy(sdf, sdf$cyl), count = n(sdf$wt))\n",
+    "SparkR::head(arrange(car_counts, desc(car_counts$count)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Operate_on_columns'></a>\n",
+    "## 5. Operate on columns\n",
+    "SparkR provides a number of functions that you can apply directly to columns for data processing. In the following example, a basic arithmetic function converts lbs to metric tons:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>wt</th><th scope=col>wtTon</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4        </td><td>2.620            </td><td>1.17900          </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag    </td><td>2.875            </td><td>1.29375          </td></tr>\n",
+       "\t<tr><td>Datsun 710       </td><td>2.320            </td><td>1.04400          </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive   </td><td>3.215            </td><td>1.44675          </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout</td><td>3.440            </td><td>1.54800          </td></tr>\n",
+       "\t<tr><td>Valiant          </td><td>3.460            </td><td>1.55700          </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|lll}\n",
+       " car & wt & wtTon\\\\\n",
+       "\\hline\n",
+       "\t Mazda RX4         & 2.620             & 1.17900          \\\\\n",
+       "\t Mazda RX4 Wag     & 2.875             & 1.29375          \\\\\n",
+       "\t Datsun 710        & 2.320             & 1.04400          \\\\\n",
+       "\t Hornet 4 Drive    & 3.215             & 1.44675          \\\\\n",
+       "\t Hornet Sportabout & 3.440             & 1.54800          \\\\\n",
+       "\t Valiant           & 3.460             & 1.55700          \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "car | wt | wtTon | \n",
+       "|---|---|---|---|---|---|\n",
+       "| Mazda RX4         | 2.620             | 1.17900           | \n",
+       "| Mazda RX4 Wag     | 2.875             | 1.29375           | \n",
+       "| Datsun 710        | 2.320             | 1.04400           | \n",
+       "| Hornet 4 Drive    | 3.215             | 1.44675           | \n",
+       "| Hornet Sportabout | 3.440             | 1.54800           | \n",
+       "| Valiant           | 3.460             | 1.55700           | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  car               wt    wtTon  \n",
+       "1 Mazda RX4         2.620 1.17900\n",
+       "2 Mazda RX4 Wag     2.875 1.29375\n",
+       "3 Datsun 710        2.320 1.04400\n",
+       "4 Hornet 4 Drive    3.215 1.44675\n",
+       "5 Hornet Sportabout 3.440 1.54800\n",
+       "6 Valiant           3.460 1.55700"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "sdf$wtTon <- sdf$wt * 0.45\n",
+    "SparkR::head(select(sdf, sdf$car, sdf$wt, sdf$wtTon),6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Run_SQL_queries_from_the_Spark_DataFrame'></a>\n",
+    "## 6. Run SQL queries from the Spark DataFrame\n",
+    "You can register a Spark DataFrame as a temporary table and then run SQL queries over the data. The `sql` function enables an application to run SQL queries programmatically and returns the result as a DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning message:\n",
+      "“'registerTempTable' is deprecated.\n",
+      "Use 'createOrReplaceTempView' instead.\n",
+      "See help(\"Deprecated\")”Warning message:\n",
+      "“'sql(sqlContext...)' is deprecated.\n",
+      "Use 'sql(sqlQuery)' instead.\n",
+      "See help(\"Deprecated\")”"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>gear</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Porsche 914-2 </td><td>5             </td></tr>\n",
+       "\t<tr><td>Lotus Europa  </td><td>5             </td></tr>\n",
+       "\t<tr><td>Ford Pantera L</td><td>5             </td></tr>\n",
+       "\t<tr><td>Ferrari Dino  </td><td>5             </td></tr>\n",
+       "\t<tr><td>Maserati Bora </td><td>5             </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/latex": [
+       "\\begin{tabular}{r|ll}\n",
+       " car & gear\\\\\n",
+       "\\hline\n",
+       "\t Porsche 914-2  & 5             \\\\\n",
+       "\t Lotus Europa   & 5             \\\\\n",
+       "\t Ford Pantera L & 5             \\\\\n",
+       "\t Ferrari Dino   & 5             \\\\\n",
+       "\t Maserati Bora  & 5             \\\\\n",
+       "\\end{tabular}\n"
+      ],
+      "text/markdown": [
+       "\n",
+       "car | gear | \n",
+       "|---|---|---|---|---|\n",
+       "| Porsche 914-2  | 5              | \n",
+       "| Lotus Europa   | 5              | \n",
+       "| Ford Pantera L | 5              | \n",
+       "| Ferrari Dino   | 5              | \n",
+       "| Maserati Bora  | 5              | \n",
+       "\n",
+       "\n"
+      ],
+      "text/plain": [
+       "  car            gear\n",
+       "1 Porsche 914-2  5   \n",
+       "2 Lotus Europa   5   \n",
+       "3 Ford Pantera L 5   \n",
+       "4 Ferrari Dino   5   \n",
+       "5 Maserati Bora  5   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "registerTempTable(sdf, \"cars\")\n",
+    "\n",
+    "highgearcars <- sql(sqlContext, \"SELECT car, gear FROM cars WHERE gear >= 5\")\n",
+    "SparkR::head(highgearcars)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## That's it!\n",
+    "You successfully completed this notebook! You learned how to load a DataFrame, view and filter the data, aggregate the data, perform operations on the data in specific columns, and run SQL queries against the data. For more information about Spark, see the [Spark Quick Start Guide](http://spark.apache.org/docs/latest/quick-start.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Want to learn more?\n",
+    "### Free courses on <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu/\" rel=\"noopener noreferrer\" target=\"_blank\">Big Data University</a>: <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu\" rel=\"noopener noreferrer\" target=\"_blank\"><img src = \"https://ibm.box.com/shared/static/xomeu7dacwufkoawbg3owc8wzuezltn6.png\" width=600px> </a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authors\n",
+    "\n",
+    "**Saeed Aghabozorgi**, PhD, is a Data Scientist in IBM with a track record of developing enterprise-level applications that substantially increases clients' ability to turn data into actionable knowledge. He is a researcher in the data mining field and an expert in developing advanced analytic methods like machine learning and statistical modelling on large data sets.\n",
+    "\n",
+    "**Polong Lin** is a Data Scientist at IBM in Canada. Under the Emerging Technologies division, Polong is responsible for educating the next generation of data scientists through Big Data University. Polong is a regular speaker in conferences and meetups, and holds an M.Sc. in Cognitive Psychology."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright © 2016, 2017 Big Data University. This notebook and its source code are released under the terms of the <a href=\"https://bigdatauniversity.com/mit-license/\" rel=\"noopener noreferrer\" target=\"_blank\">MIT License</a>."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - R (YARN Client Mode)",
+   "language": "R",
+   "name": "spark_2.1_r_yarn_client"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.4.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
@@ -1,0 +1,657 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use Spark for R to load data and run SQL queries\n",
+    "This notebook introduces basic Spark concepts and helps you to start using Spark for R.\n",
+    "\n",
+    "Some familiarity with R is recommended. This notebook runs on R with Spark 2.0.\n",
+    "\n",
+    "In this notebook, you'll use the publicly available **mtcars** data set from *Motor Trend* magazine to learn some basic R. You'll learn how to load data, create a Spark DataFrame, aggregate data, run mathematical formulas, and run SQL queries against the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table of contents\n",
+    "This notebook contains these main sections:\n",
+    "\n",
+    "1. [Load a DataFrame](#Load_a_DataFrame)\n",
+    "2. [Initialize an SQLContext](#Initialize_an_SQLContext)\n",
+    "3. [Create a Spark DataFrame](#Create_a_Spark_DataFrame)\n",
+    "4. [Aggregate data after grouping by columns](#Aggregate_data_after_grouping_by_columns)\n",
+    "5. [Operate on columns](#Operate_on_columns)\n",
+    "6. [Run SQL queries from the Spark DataFrame](#Run_SQL_queries_from_the_Spark_DataFrame)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Load_a_DataFrame'></a>\n",
+    "## 1. Load a DataFrame\n",
+    "A DataFrame is a distributed collection of data that is organized into named columns. The built-in R DataFrame called **mtcars** includes observations on the following 11 variables:\n",
+    "\n",
+    "`[, 1]\tmpg     Miles / (US) gallon`  \n",
+    "`[, 2]\tcyl     Number of cylinders`  \n",
+    "`[, 3]\tdisp\tDisplacement (cu. in.)`  \n",
+    "`[, 4]\thp      Gross horsepower`  \n",
+    "`[, 5]\tdrat    Rear axle ratio`  \n",
+    "`[, 6]\twt      Weight (1000 lbs)`  \n",
+    "`[, 7]\tqsec    1/4 mile time (seconds)`  \n",
+    "`[, 8]\tvs      0 = V-engine, 1 = straight engine`  \n",
+    "`[, 9]\tam      Transmission (0 = automatic, 1 = manual)`  \n",
+    "`[,10]\tgear    Number of forward gears`  \n",
+    "`[,11]\tcarb    Number of carburetors`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Preview the first 3 rows of the DataFrame by using the head() function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th></th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><th scope=row>Mazda RX4</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.620</td><td>16.46</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
+       "\t<tr><th scope=row>Mazda RX4 Wag</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.875</td><td>17.02</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
+       "\t<tr><th scope=row>Datsun 710</th><td>22.8 </td><td>4    </td><td>108  </td><td> 93  </td><td>3.85 </td><td>2.320</td><td>18.61</td><td>1    </td><td>1    </td><td>4    </td><td>1    </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "              mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
+       "Mazda RX4     21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
+       "Mazda RX4 Wag 21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
+       "Datsun 710    22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "# Since this display_data would be transformed into mark down of <table></table>\n",
+    "head(mtcars, 3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert the car name data, which appears in the row names, into an actual column so that Spark can read it as a column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4        </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.620            </td><td>16.46            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag    </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.875            </td><td>17.02            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
+       "\t<tr><td>Datsun 710       </td><td>22.8             </td><td>4                </td><td>108              </td><td> 93              </td><td>3.85             </td><td>2.320            </td><td>18.61            </td><td>1                </td><td>1                </td><td>4                </td><td>1                </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive   </td><td>21.4             </td><td>6                </td><td>258              </td><td>110              </td><td>3.08             </td><td>3.215            </td><td>19.44            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout</td><td>18.7             </td><td>8                </td><td>360              </td><td>175              </td><td>3.15             </td><td>3.440            </td><td>17.02            </td><td>0                </td><td>0                </td><td>3                </td><td>2                </td></tr>\n",
+       "\t<tr><td>Valiant          </td><td>18.1             </td><td>6                </td><td>225              </td><td>105              </td><td>2.76             </td><td>3.460            </td><td>20.22            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  car               mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
+       "1 Mazda RX4         21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
+       "2 Mazda RX4 Wag     21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
+       "3 Datsun 710        22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   \n",
+       "4 Hornet 4 Drive    21.4 6   258  110 3.08 3.215 19.44 1  0  3    1   \n",
+       "5 Hornet Sportabout 18.7 8   360  175 3.15 3.440 17.02 0  0  3    2   \n",
+       "6 Valiant           18.1 6   225  105 2.76 3.460 20.22 1  0  3    1   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "mtcars$car <- rownames(mtcars)\n",
+    "mtcars <- mtcars[,c(12,1:11)]\n",
+    "rownames(mtcars) <- 1:nrow(mtcars)\n",
+    "head(mtcars)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Initialize_an_SQLContext'></a>\n",
+    "## 2. Initialize an SQLContext\n",
+    "To work with a DataFrame, you need an SQLContext. You create this SQLContext by using `sparkRSQL.init(sc)`. A SparkContext named sc, which has been created for you, is used to initialize the SQLContext:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sqlContext <- sparkR.session(sc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Create_a_Spark_DataFrame'></a>\n",
+    "## 3. Create a Spark DataFrame\n",
+    "Using the SQLContext and the loaded local DataFrame, create a Spark DataFrame and print the schema, or structure, of the DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- car: string (nullable = true)\n",
+      " |-- mpg: double (nullable = true)\n",
+      " |-- cyl: double (nullable = true)\n",
+      " |-- disp: double (nullable = true)\n",
+      " |-- hp: double (nullable = true)\n",
+      " |-- drat: double (nullable = true)\n",
+      " |-- wt: double (nullable = true)\n",
+      " |-- qsec: double (nullable = true)\n",
+      " |-- vs: double (nullable = true)\n",
+      " |-- am: double (nullable = true)\n",
+      " |-- gear: double (nullable = true)\n",
+      " |-- carb: double (nullable = true)\n"
+     ]
+    }
+   ],
+   "source": [
+    "sdf <- createDataFrame(mtcars, schema = NULL) \n",
+    "printSchema(sdf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the content of the Spark DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4          </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.620              </td><td>16.46              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag      </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.875              </td><td>17.02              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Datsun 710         </td><td>22.8               </td><td>4                  </td><td>108.0              </td><td> 93                </td><td>3.85               </td><td>2.320              </td><td>18.61              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive     </td><td>21.4               </td><td>6                  </td><td>258.0              </td><td>110                </td><td>3.08               </td><td>3.215              </td><td>19.44              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout  </td><td>18.7               </td><td>8                  </td><td>360.0              </td><td>175                </td><td>3.15               </td><td>3.440              </td><td>17.02              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Valiant            </td><td>18.1               </td><td>6                  </td><td>225.0              </td><td>105                </td><td>2.76               </td><td>3.460              </td><td>20.22              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Duster 360         </td><td>14.3               </td><td>8                  </td><td>360.0              </td><td>245                </td><td>3.21               </td><td>3.570              </td><td>15.84              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 240D          </td><td>24.4               </td><td>4                  </td><td>146.7              </td><td> 62                </td><td>3.69               </td><td>3.190              </td><td>20.00              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Merc 230           </td><td>22.8               </td><td>4                  </td><td>140.8              </td><td> 95                </td><td>3.92               </td><td>3.150              </td><td>22.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Merc 280           </td><td>19.2               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.30              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 280C          </td><td>17.8               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Merc 450SE         </td><td>16.4               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>4.070              </td><td>17.40              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Merc 450SL         </td><td>17.3               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.730              </td><td>17.60              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Merc 450SLC        </td><td>15.2               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.780              </td><td>18.00              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
+       "\t<tr><td>Cadillac Fleetwood </td><td>10.4               </td><td>8                  </td><td>472.0              </td><td>205                </td><td>2.93               </td><td>5.250              </td><td>17.98              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Lincoln Continental</td><td>10.4               </td><td>8                  </td><td>460.0              </td><td>215                </td><td>3.00               </td><td>5.424              </td><td>17.82              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Chrysler Imperial  </td><td>14.7               </td><td>8                  </td><td>440.0              </td><td>230                </td><td>3.23               </td><td>5.345              </td><td>17.42              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Fiat 128           </td><td>32.4               </td><td>4                  </td><td> 78.7              </td><td> 66                </td><td>4.08               </td><td>2.200              </td><td>19.47              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Honda Civic        </td><td>30.4               </td><td>4                  </td><td> 75.7              </td><td> 52                </td><td>4.93               </td><td>1.615              </td><td>18.52              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Toyota Corolla     </td><td>33.9               </td><td>4                  </td><td> 71.1              </td><td> 65                </td><td>4.22               </td><td>1.835              </td><td>19.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Toyota Corona      </td><td>21.5               </td><td>4                  </td><td>120.1              </td><td> 97                </td><td>3.70               </td><td>2.465              </td><td>20.01              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Dodge Challenger   </td><td>15.5               </td><td>8                  </td><td>318.0              </td><td>150                </td><td>2.76               </td><td>3.520              </td><td>16.87              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>AMC Javelin        </td><td>15.2               </td><td>8                  </td><td>304.0              </td><td>150                </td><td>3.15               </td><td>3.435              </td><td>17.30              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Camaro Z28         </td><td>13.3               </td><td>8                  </td><td>350.0              </td><td>245                </td><td>3.73               </td><td>3.840              </td><td>15.41              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Pontiac Firebird   </td><td>19.2               </td><td>8                  </td><td>400.0              </td><td>175                </td><td>3.08               </td><td>3.845              </td><td>17.05              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Fiat X1-9          </td><td>27.3               </td><td>4                  </td><td> 79.0              </td><td> 66                </td><td>4.08               </td><td>1.935              </td><td>18.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
+       "\t<tr><td>Porsche 914-2      </td><td>26.0               </td><td>4                  </td><td>120.3              </td><td> 91                </td><td>4.43               </td><td>2.140              </td><td>16.70              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Lotus Europa       </td><td>30.4               </td><td>4                  </td><td> 95.1              </td><td>113                </td><td>3.77               </td><td>1.513              </td><td>16.90              </td><td>1                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
+       "\t<tr><td>Ford Pantera L     </td><td>15.8               </td><td>8                  </td><td>351.0              </td><td>264                </td><td>4.22               </td><td>3.170              </td><td>14.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>4                  </td></tr>\n",
+       "\t<tr><td>Ferrari Dino       </td><td>19.7               </td><td>6                  </td><td>145.0              </td><td>175                </td><td>3.62               </td><td>2.770              </td><td>15.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>6                  </td></tr>\n",
+       "\t<tr><td>Maserati Bora      </td><td>15.0               </td><td>8                  </td><td>301.0              </td><td>335                </td><td>3.54               </td><td>3.570              </td><td>14.60              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>8                  </td></tr>\n",
+       "\t<tr><td>Volvo 142E         </td><td>21.4               </td><td>4                  </td><td>121.0              </td><td>109                </td><td>4.11               </td><td>2.780              </td><td>18.60              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "   car                 mpg  cyl disp  hp  drat wt    qsec  vs am gear carb\n",
+       "1  Mazda RX4           21.0 6   160.0 110 3.90 2.620 16.46 0  1  4    4   \n",
+       "2  Mazda RX4 Wag       21.0 6   160.0 110 3.90 2.875 17.02 0  1  4    4   \n",
+       "3  Datsun 710          22.8 4   108.0  93 3.85 2.320 18.61 1  1  4    1   \n",
+       "4  Hornet 4 Drive      21.4 6   258.0 110 3.08 3.215 19.44 1  0  3    1   \n",
+       "5  Hornet Sportabout   18.7 8   360.0 175 3.15 3.440 17.02 0  0  3    2   \n",
+       "6  Valiant             18.1 6   225.0 105 2.76 3.460 20.22 1  0  3    1   \n",
+       "7  Duster 360          14.3 8   360.0 245 3.21 3.570 15.84 0  0  3    4   \n",
+       "8  Merc 240D           24.4 4   146.7  62 3.69 3.190 20.00 1  0  4    2   \n",
+       "9  Merc 230            22.8 4   140.8  95 3.92 3.150 22.90 1  0  4    2   \n",
+       "10 Merc 280            19.2 6   167.6 123 3.92 3.440 18.30 1  0  4    4   \n",
+       "11 Merc 280C           17.8 6   167.6 123 3.92 3.440 18.90 1  0  4    4   \n",
+       "12 Merc 450SE          16.4 8   275.8 180 3.07 4.070 17.40 0  0  3    3   \n",
+       "13 Merc 450SL          17.3 8   275.8 180 3.07 3.730 17.60 0  0  3    3   \n",
+       "14 Merc 450SLC         15.2 8   275.8 180 3.07 3.780 18.00 0  0  3    3   \n",
+       "15 Cadillac Fleetwood  10.4 8   472.0 205 2.93 5.250 17.98 0  0  3    4   \n",
+       "16 Lincoln Continental 10.4 8   460.0 215 3.00 5.424 17.82 0  0  3    4   \n",
+       "17 Chrysler Imperial   14.7 8   440.0 230 3.23 5.345 17.42 0  0  3    4   \n",
+       "18 Fiat 128            32.4 4    78.7  66 4.08 2.200 19.47 1  1  4    1   \n",
+       "19 Honda Civic         30.4 4    75.7  52 4.93 1.615 18.52 1  1  4    2   \n",
+       "20 Toyota Corolla      33.9 4    71.1  65 4.22 1.835 19.90 1  1  4    1   \n",
+       "21 Toyota Corona       21.5 4   120.1  97 3.70 2.465 20.01 1  0  3    1   \n",
+       "22 Dodge Challenger    15.5 8   318.0 150 2.76 3.520 16.87 0  0  3    2   \n",
+       "23 AMC Javelin         15.2 8   304.0 150 3.15 3.435 17.30 0  0  3    2   \n",
+       "24 Camaro Z28          13.3 8   350.0 245 3.73 3.840 15.41 0  0  3    4   \n",
+       "25 Pontiac Firebird    19.2 8   400.0 175 3.08 3.845 17.05 0  0  3    2   \n",
+       "26 Fiat X1-9           27.3 4    79.0  66 4.08 1.935 18.90 1  1  4    1   \n",
+       "27 Porsche 914-2       26.0 4   120.3  91 4.43 2.140 16.70 0  1  5    2   \n",
+       "28 Lotus Europa        30.4 4    95.1 113 3.77 1.513 16.90 1  1  5    2   \n",
+       "29 Ford Pantera L      15.8 8   351.0 264 4.22 3.170 14.50 0  1  5    4   \n",
+       "30 Ferrari Dino        19.7 6   145.0 175 3.62 2.770 15.50 0  1  5    6   \n",
+       "31 Maserati Bora       15.0 8   301.0 335 3.54 3.570 14.60 0  1  5    8   \n",
+       "32 Volvo 142E          21.4 4   121.0 109 4.11 2.780 18.60 1  1  4    2   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(sdf, 32)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try different ways of retrieving subsets of the data. For example, get the first 5 values in the **mpg** column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>mpg</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>21.0</td></tr>\n",
+       "\t<tr><td>21.0</td></tr>\n",
+       "\t<tr><td>22.8</td></tr>\n",
+       "\t<tr><td>21.4</td></tr>\n",
+       "\t<tr><td>18.7</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  mpg \n",
+       "1 21.0\n",
+       "2 21.0\n",
+       "3 22.8\n",
+       "4 21.4\n",
+       "5 18.7"
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(select(sdf, sdf$mpg),5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filter the DataFrame to retain only rows with **mpg** values that are less than 18:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Duster 360        </td><td>14.3              </td><td>8                 </td><td>360.0             </td><td>245               </td><td>3.21              </td><td>3.57              </td><td>15.84             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
+       "\t<tr><td>Merc 280C         </td><td>17.8              </td><td>6                 </td><td>167.6             </td><td>123               </td><td>3.92              </td><td>3.44              </td><td>18.90             </td><td>1                 </td><td>0                 </td><td>4                 </td><td>4                 </td></tr>\n",
+       "\t<tr><td>Merc 450SE        </td><td>16.4              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>4.07              </td><td>17.40             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Merc 450SL        </td><td>17.3              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.73              </td><td>17.60             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Merc 450SLC       </td><td>15.2              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.78              </td><td>18.00             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
+       "\t<tr><td>Cadillac Fleetwood</td><td>10.4              </td><td>8                 </td><td>472.0             </td><td>205               </td><td>2.93              </td><td>5.25              </td><td>17.98             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  car                mpg  cyl disp  hp  drat wt   qsec  vs am gear carb\n",
+       "1 Duster 360         14.3 8   360.0 245 3.21 3.57 15.84 0  0  3    4   \n",
+       "2 Merc 280C          17.8 6   167.6 123 3.92 3.44 18.90 1  0  4    4   \n",
+       "3 Merc 450SE         16.4 8   275.8 180 3.07 4.07 17.40 0  0  3    3   \n",
+       "4 Merc 450SL         17.3 8   275.8 180 3.07 3.73 17.60 0  0  3    3   \n",
+       "5 Merc 450SLC        15.2 8   275.8 180 3.07 3.78 18.00 0  0  3    3   \n",
+       "6 Cadillac Fleetwood 10.4 8   472.0 205 2.93 5.25 17.98 0  0  3    4   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(SparkR::filter(sdf, sdf$mpg < 18))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Aggregate_data_after_grouping_by_columns'></a>\n",
+    "## 4. Aggregate data after grouping by columns\n",
+    "Spark DataFrames support a number of common functions to aggregate data after grouping. For example, you can compute the average weight of cars as a function of the number of cylinders:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>cyl</th><th scope=col>wtavg</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>8       </td><td>3.999214</td></tr>\n",
+       "\t<tr><td>4       </td><td>2.285727</td></tr>\n",
+       "\t<tr><td>6       </td><td>3.117143</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  cyl wtavg   \n",
+       "1 8   3.999214\n",
+       "2 4   2.285727\n",
+       "3 6   3.117143"
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "SparkR::head(summarize(groupBy(sdf, sdf$cyl), wtavg = avg(sdf$wt)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also sort the output from the aggregation to determine the most popular cylinder configuration in the DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>cyl</th><th scope=col>count</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>8 </td><td>14</td></tr>\n",
+       "\t<tr><td>4 </td><td>11</td></tr>\n",
+       "\t<tr><td>6 </td><td> 7</td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  cyl count\n",
+       "1 8   14   \n",
+       "2 4   11   \n",
+       "3 6    7   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "car_counts <-summarize(groupBy(sdf, sdf$cyl), count = n(sdf$wt))\n",
+    "SparkR::head(arrange(car_counts, desc(car_counts$count)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Operate_on_columns'></a>\n",
+    "## 5. Operate on columns\n",
+    "SparkR provides a number of functions that you can apply directly to columns for data processing. In the following example, a basic arithmetic function converts lbs to metric tons:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>wt</th><th scope=col>wtTon</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Mazda RX4        </td><td>2.620            </td><td>1.17900          </td></tr>\n",
+       "\t<tr><td>Mazda RX4 Wag    </td><td>2.875            </td><td>1.29375          </td></tr>\n",
+       "\t<tr><td>Datsun 710       </td><td>2.320            </td><td>1.04400          </td></tr>\n",
+       "\t<tr><td>Hornet 4 Drive   </td><td>3.215            </td><td>1.44675          </td></tr>\n",
+       "\t<tr><td>Hornet Sportabout</td><td>3.440            </td><td>1.54800          </td></tr>\n",
+       "\t<tr><td>Valiant          </td><td>3.460            </td><td>1.55700          </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  car               wt    wtTon  \n",
+       "1 Mazda RX4         2.620 1.17900\n",
+       "2 Mazda RX4 Wag     2.875 1.29375\n",
+       "3 Datsun 710        2.320 1.04400\n",
+       "4 Hornet 4 Drive    3.215 1.44675\n",
+       "5 Hornet Sportabout 3.440 1.54800\n",
+       "6 Valiant           3.460 1.55700"
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "sdf$wtTon <- sdf$wt * 0.45\n",
+    "SparkR::head(select(sdf, sdf$car, sdf$wt, sdf$wtTon),6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Run_SQL_queries_from_the_Spark_DataFrame'></a>\n",
+    "## 6. Run SQL queries from the Spark DataFrame\n",
+    "You can register a Spark DataFrame as a temporary table and then run SQL queries over the data. The `sql` function enables an application to run SQL queries programmatically and returns the result as a DataFrame:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Warning message:\n",
+      "“'registerTempTable' is deprecated.\n",
+      "Use 'createOrReplaceTempView' instead.\n",
+      "See help(\"Deprecated\")”Warning message:\n",
+      "“'sql(sqlContext...)' is deprecated.\n",
+      "Use 'sql(sqlQuery)' instead.\n",
+      "See help(\"Deprecated\")”"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table>\n",
+       "<thead><tr><th scope=col>car</th><th scope=col>gear</th></tr></thead>\n",
+       "<tbody>\n",
+       "\t<tr><td>Porsche 914-2 </td><td>5             </td></tr>\n",
+       "\t<tr><td>Lotus Europa  </td><td>5             </td></tr>\n",
+       "\t<tr><td>Ford Pantera L</td><td>5             </td></tr>\n",
+       "\t<tr><td>Ferrari Dino  </td><td>5             </td></tr>\n",
+       "\t<tr><td>Maserati Bora </td><td>5             </td></tr>\n",
+       "</tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "  car            gear\n",
+       "1 Porsche 914-2  5   \n",
+       "2 Lotus Europa   5   \n",
+       "3 Ford Pantera L 5   \n",
+       "4 Ferrari Dino   5   \n",
+       "5 Maserati Bora  5   "
+      ]
+     },
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#DEPENDS\n",
+    "registerTempTable(sdf, \"cars\")\n",
+    "\n",
+    "highgearcars <- sql(sqlContext, \"SELECT car, gear FROM cars WHERE gear >= 5\")\n",
+    "SparkR::head(highgearcars)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## That's it!\n",
+    "You successfully completed this notebook! You learned how to load a DataFrame, view and filter the data, aggregate the data, perform operations on the data in specific columns, and run SQL queries against the data. For more information about Spark, see the [Spark Quick Start Guide](http://spark.apache.org/docs/latest/quick-start.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Want to learn more?\n",
+    "### Free courses on <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu/\" rel=\"noopener noreferrer\" target=\"_blank\">Big Data University</a>: <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu\" rel=\"noopener noreferrer\" target=\"_blank\"><img src = \"https://ibm.box.com/shared/static/xomeu7dacwufkoawbg3owc8wzuezltn6.png\" width=600px> </a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authors\n",
+    "\n",
+    "**Saeed Aghabozorgi**, PhD, is a Data Scientist in IBM with a track record of developing enterprise-level applications that substantially increases clients' ability to turn data into actionable knowledge. He is a researcher in the data mining field and an expert in developing advanced analytic methods like machine learning and statistical modelling on large data sets.\n",
+    "\n",
+    "**Polong Lin** is a Data Scientist at IBM in Canada. Under the Emerging Technologies division, Polong is responsible for educating the next generation of data scientists through Big Data University. Polong is a regular speaker in conferences and meetups, and holds an M.Sc. in Cognitive Psychology."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright © 2016, 2017 Big Data University. This notebook and its source code are released under the terms of the <a href=\"https://bigdatauniversity.com/mit-license/\" rel=\"noopener noreferrer\" target=\"_blank\">MIT License</a>."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - R (YARN Cluster Mode)",
+   "language": "R",
+   "name": "spark_2.1_r_yarn_cluster"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.4.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
@@ -1,0 +1,407 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AAAA\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(\"AAAA\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the application name and application ID with YARN RM web UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Waiting for a Spark session to start..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c0a95d8d-b6ed-4551-bea4-d2bb37f1dea3\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "application_1502395407456_0091"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "//DIFFERENT\n",
+    "println(sc.appName)\n",
+    "sc.applicationId"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the application config parameters with YARN RM web UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "conf = org.apache.spark.SparkConf@4be04e70\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "org.apache.spark.SparkConf@4be04e70"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "var conf = sc.getConf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "yarn\n",
+      "client\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(conf.get(\"spark.master\"))\n",
+    "println(conf.get(\"spark.submit.deployMode\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the host where the Kernel is running on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "//DEPENDS\n",
+    "println(conf.get(\"spark.driver.host\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add Jar magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Name: Compile Error\n",
+       "Message: <console>:27: error: object lwjgl is not a member of package org\n",
+       "       org.lwjgl.Version.getVersion()\n",
+       "           ^\n",
+       "\n",
+       "StackTrace: "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Will throw Compile Error\n",
+    "org.lwjgl.Version.getVersion()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The JAR file will be downloaded to the driver host, under path:\n",
+    "#### /hadoop/yarn/local/usercache/[username]/appcache/[appID]/[containerID]/tmp/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting download from https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar\n",
+      "Finished download of lwjgl-3.0.0b.jar\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "error: error while loading Encoders, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Encoders.class)' has location not matching its contents: contains class Encoders\n",
+       "error: error while loading RowFactory, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RowFactory.class)' has location not matching its contents: contains class RowFactory\n",
+       "error: error while loading AnalysisException, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/AnalysisException.class)' has location not matching its contents: contains class AnalysisException\n",
+       "error: error while loading functions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/functions.class)' has location not matching its contents: contains class functions\n",
+       "error: error while loading DataFrameStatFunctions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameStatFunctions.class)' has location not matching its contents: contains class DataFrameStatFunctions\n",
+       "error: error while loading ForeachWriter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/ForeachWriter.class)' has location not matching its contents: contains class ForeachWriter\n",
+       "error: error while loading SaveMode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/SaveMode.class)' has location not matching its contents: contains class SaveMode\n",
+       "error: error while loading RelationalGroupedDataset, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RelationalGroupedDataset.class)' has location not matching its contents: contains class RelationalGroupedDataset\n",
+       "error: error while loading DataFrameNaFunctions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameNaFunctions.class)' has location not matching its contents: contains class DataFrameNaFunctions\n",
+       "error: error while loading Column, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Column.class)' has location not matching its contents: contains class Column\n",
+       "error: error while loading TypedColumn, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/TypedColumn.class)' has location not matching its contents: contains class TypedColumn\n",
+       "error: error while loading KeyValueGroupedDataset, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/KeyValueGroupedDataset.class)' has location not matching its contents: contains class KeyValueGroupedDataset\n",
+       "error: error while loading DataFrameWriter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameWriter.class)' has location not matching its contents: contains class DataFrameWriter\n",
+       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-hive_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/hive/package.class)' has location not matching its contents: contains package object hive\n",
+       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/api/package.class)' has location not matching its contents: contains package object api\n",
+       "error: error while loading UnsafeExternalRowSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeExternalRowSorter.class)' has location not matching its contents: contains class UnsafeExternalRowSorter\n",
+       "error: error while loading UnsafeKeyValueSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKeyValueSorter.class)' has location not matching its contents: contains class UnsafeKeyValueSorter\n",
+       "error: error while loading CacheManager, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CacheManager.class)' has location not matching its contents: contains class CacheManager\n",
+       "error: error while loading PartitionIdPassthrough, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PartitionIdPassthrough.class)' has location not matching its contents: contains class PartitionIdPassthrough\n",
+       "error: error while loading SparkSqlAstBuilder, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlAstBuilder.class)' has location not matching its contents: contains class SparkSqlAstBuilder\n",
+       "error: error while loading MapPartitionsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapPartitionsExec.class)' has location not matching its contents: contains class MapPartitionsExec\n",
+       "error: error while loading ExpandExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExpandExec.class)' has location not matching its contents: contains class ExpandExec\n",
+       "error: error while loading UnaryExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnaryExecNode.class)' has location not matching its contents: contains class UnaryExecNode\n",
+       "error: error while loading SampleExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SampleExec.class)' has location not matching its contents: contains class SampleExec\n",
+       "error: error while loading ExternalRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDD.class)' has location not matching its contents: contains class ExternalRDD\n",
+       "error: error while loading LocalTableScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalTableScanExec.class)' has location not matching its contents: contains class LocalTableScanExec\n",
+       "error: error while loading LazyIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LazyIterator.class)' has location not matching its contents: contains class LazyIterator\n",
+       "error: error while loading InSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InSubquery.class)' has location not matching its contents: contains class InSubquery\n",
+       "error: error while loading SQLExecution, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SQLExecution.class)' has location not matching its contents: contains class SQLExecution\n",
+       "error: error while loading MapGroupsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapGroupsExec.class)' has location not matching its contents: contains class MapGroupsExec\n",
+       "error: error while loading SparkSqlParser, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlParser.class)' has location not matching its contents: contains class SparkSqlParser\n",
+       "error: error while loading CoGroupedIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupedIterator.class)' has location not matching its contents: contains class CoGroupedIterator\n",
+       "error: error while loading MapElementsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapElementsExec.class)' has location not matching its contents: contains class MapElementsExec\n",
+       "error: error while loading SparkPlan, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlan.class)' has location not matching its contents: contains class SparkPlan\n",
+       "error: error while loading FileRelation, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileRelation.class)' has location not matching its contents: contains class FileRelation\n",
+       "error: error while loading UnsafeFixedWidthAggregationMap, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.class)' has location not matching its contents: contains class UnsafeFixedWidthAggregationMap\n",
+       "error: error while loading LogicalRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LogicalRDD.class)' has location not matching its contents: contains class LogicalRDD\n",
+       "error: error while loading OutputFakerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OutputFakerExec.class)' has location not matching its contents: contains class OutputFakerExec\n",
+       "error: error while loading ShuffledRowRDDPartition, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDDPartition.class)' has location not matching its contents: contains class ShuffledRowRDDPartition\n",
+       "error: error while loading RowDataSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowDataSourceScanExec.class)' has location not matching its contents: contains class RowDataSourceScanExec\n",
+       "error: error while loading SparkPlanInfo, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanInfo.class)' has location not matching its contents: contains class SparkPlanInfo\n",
+       "error: error while loading BaseLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BaseLimitExec.class)' has location not matching its contents: contains class BaseLimitExec\n",
+       "error: error while loading WholeStageCodegenExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/WholeStageCodegenExec.class)' has location not matching its contents: contains class WholeStageCodegenExec\n",
+       "error: error while loading SortExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortExec.class)' has location not matching its contents: contains class SortExec\n",
+       "error: error while loading ObjectProducerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectProducerExec.class)' has location not matching its contents: contains class ObjectProducerExec\n",
+       "error: error while loading InputAdapter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InputAdapter.class)' has location not matching its contents: contains class InputAdapter\n",
+       "error: error while loading ScalarSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ScalarSubquery.class)' has location not matching its contents: contains class ScalarSubquery\n",
+       "error: error while loading FileSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileSourceScanExec.class)' has location not matching its contents: contains class FileSourceScanExec\n",
+       "error: error while loading ProjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ProjectExec.class)' has location not matching its contents: contains class ProjectExec\n",
+       "error: error while loading RowIteratorFromScala, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorFromScala.class)' has location not matching its contents: contains class RowIteratorFromScala\n",
+       "error: error while loading RowIteratorToScala, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorToScala.class)' has location not matching its contents: contains class RowIteratorToScala\n",
+       "error: error while loading ObjectOperator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectOperator.class)' has location not matching its contents: contains class ObjectOperator\n",
+       "error: error while loading PlanLater, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanLater.class)' has location not matching its contents: contains class PlanLater\n",
+       "error: error while loading RowIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIterator.class)' has location not matching its contents: contains class RowIterator\n",
+       "error: error while loading FlatMapGroupsInRExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FlatMapGroupsInRExec.class)' has location not matching its contents: contains class FlatMapGroupsInRExec\n",
+       "error: error while loading TakeOrderedAndProjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/TakeOrderedAndProjectExec.class)' has location not matching its contents: contains class TakeOrderedAndProjectExec\n",
+       "error: error while loading AppendColumnsWithObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsWithObjectExec.class)' has location not matching its contents: contains class AppendColumnsWithObjectExec\n",
+       "error: error while loading LocalLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalLimitExec.class)' has location not matching its contents: contains class LocalLimitExec\n",
+       "error: error while loading UnionExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnionExec.class)' has location not matching its contents: contains class UnionExec\n",
+       "error: error while loading PlanSubqueries, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanSubqueries.class)' has location not matching its contents: contains class PlanSubqueries\n",
+       "error: error while loading CodegenSupport, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CodegenSupport.class)' has location not matching its contents: contains class CodegenSupport\n",
+       "error: error while loading ObjectConsumerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectConsumerExec.class)' has location not matching its contents: contains class ObjectConsumerExec\n",
+       "error: error while loading CoalesceExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalesceExec.class)' has location not matching its contents: contains class CoalesceExec\n",
+       "error: error while loading ShuffledRowRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDD.class)' has location not matching its contents: contains class ShuffledRowRDD\n",
+       "error: error while loading SubqueryExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SubqueryExec.class)' has location not matching its contents: contains class SubqueryExec\n",
+       "error: error while loading GroupedIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GroupedIterator.class)' has location not matching its contents: contains class GroupedIterator\n",
+       "error: error while loading RDDConversions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDConversions.class)' has location not matching its contents: contains class RDDConversions\n",
+       "error: error while loading OptimizeMetadataOnlyQuery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.class)' has location not matching its contents: contains class OptimizeMetadataOnlyQuery\n",
+       "error: error while loading QueryExecution, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecution.class)' has location not matching its contents: contains class QueryExecution\n",
+       "error: error while loading LeafExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LeafExecNode.class)' has location not matching its contents: contains class LeafExecNode\n",
+       "error: error while loading CollapseCodegenStages, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollapseCodegenStages.class)' has location not matching its contents: contains class CollapseCodegenStages\n",
+       "error: error while loading QueryExecutionException, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecutionException.class)' has location not matching its contents: contains class QueryExecutionException\n",
+       "error: error while loading CoGroupExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupExec.class)' has location not matching its contents: contains class CoGroupExec\n",
+       "error: error while loading ExecSubqueryExpression, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExecSubqueryExpression.class)' has location not matching its contents: contains class ExecSubqueryExpression\n",
+       "error: error while loading BufferedRowIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BufferedRowIterator.class)' has location not matching its contents: contains class BufferedRowIterator\n",
+       "error: error while loading RDDScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDScanExec.class)' has location not matching its contents: contains class RDDScanExec\n",
+       "error: error while loading AppendColumnsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsExec.class)' has location not matching its contents: contains class AppendColumnsExec\n",
+       "error: error while loading DataSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DataSourceScanExec.class)' has location not matching its contents: contains class DataSourceScanExec\n",
+       "error: error while loading SerializeFromObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SerializeFromObjectExec.class)' has location not matching its contents: contains class SerializeFromObjectExec\n",
+       "error: error while loading ExternalRDDScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDDScanExec.class)' has location not matching its contents: contains class ExternalRDDScanExec\n",
+       "error: error while loading CoalescedPartitioner, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalescedPartitioner.class)' has location not matching its contents: contains class CoalescedPartitioner\n",
+       "error: error while loading UnsafeKVExternalSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKVExternalSorter.class)' has location not matching its contents: contains class UnsafeKVExternalSorter\n",
+       "error: error while loading SparkOptimizer, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkOptimizer.class)' has location not matching its contents: contains class SparkOptimizer\n",
+       "error: error while loading DeserializeToObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DeserializeToObjectExec.class)' has location not matching its contents: contains class DeserializeToObjectExec\n",
+       "error: error while loading SparkStrategies, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategies.class)' has location not matching its contents: contains class SparkStrategies\n",
+       "error: error while loading CollectLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollectLimitExec.class)' has location not matching its contents: contains class CollectLimitExec\n",
+       "error: error while loading RangeExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RangeExec.class)' has location not matching its contents: contains class RangeExec\n",
+       "error: error while loading ReuseSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ReuseSubquery.class)' has location not matching its contents: contains class ReuseSubquery\n",
+       "error: error while loading SparkStrategy, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategy.class)' has location not matching its contents: contains class SparkStrategy\n",
+       "error: error while loading GlobalLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GlobalLimitExec.class)' has location not matching its contents: contains class GlobalLimitExec\n",
+       "error: error while loading GenerateExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GenerateExec.class)' has location not matching its contents: contains class GenerateExec\n",
+       "error: error while loading UnsafeRowSerializer, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializer.class)' has location not matching its contents: contains class UnsafeRowSerializer\n",
+       "error: error while loading CachedData, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CachedData.class)' has location not matching its contents: contains class CachedData\n",
+       "error: error while loading SortPrefixUtils, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortPrefixUtils.class)' has location not matching its contents: contains class SortPrefixUtils\n",
+       "error: error while loading SparkPlanner, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanner.class)' has location not matching its contents: contains class SparkPlanner\n",
+       "error: error while loading BinaryExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BinaryExecNode.class)' has location not matching its contents: contains class BinaryExecNode\n",
+       "error: error while loading UnsafeRowSerializerInstance, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializerInstance.class)' has location not matching its contents: contains class UnsafeRowSerializerInstance\n",
+       "error: error while loading FilterExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FilterExec.class)' has location not matching its contents: contains class FilterExec\n",
+       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/joins/package.class)' has location not matching its contents: contains package object joins\n",
+       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/debug/package.class)' has location not matching its contents: contains package object debug\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "%addjar -f https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0.0b SNAPSHOT"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "org.lwjgl.Version.getVersion()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(spark.history.kerberos.keytab,none)\n",
+      "(spark.eventLog.enabled,true)\n",
+      "(spark.history.ui.port,18081)\n",
+      "(spark.driver.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
+      "(hive.metastore.warehouse.dir,file:/home/elyra/spark-warehouse/)\n",
+      "(spark.executor.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
+      "(spark.driver.appUIAddress,http://172.16.210.224:4040)\n",
+      "(spark.repl.class.uri,spark://172.16.210.224:43007/classes)\n",
+      "(spark.repl.class.outputDir,/tmp/spark-aa235d19-9a2f-4684-a177-d6cd01a5f7a5/repl-17a8484a-6a9d-4e95-8c8e-61d5537e7d42)\n",
+      "(spark.history.provider,org.apache.spark.deploy.history.FsHistoryProvider)\n",
+      "(spark.submit.deployMode,client)\n",
+      "(spark.ui.filters,org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter)\n",
+      "(spark.eventLog.dir,hdfs:///spark2-history/)\n",
+      "(spark.driver.host,172.16.210.224)\n",
+      "(spark.yarn.historyServer.address,soldier-master.fyre.ibm.com:18081)\n",
+      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib/toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
+      "(spark.yarn.secondary.jars,toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
+      "(spark.yarn.queue,default)\n",
+      "(spark.executor.id,driver)\n",
+      "(spark.app.name,c0a95d8d-b6ed-4551-bea4-d2bb37f1dea3)\n",
+      "(spark.driver.port,43007)\n",
+      "(spark.history.fs.logDirectory,hdfs:///spark2-history/)\n",
+      "(spark.master,yarn)\n",
+      "(spark.app.id,application_1502395407456_0091)\n",
+      "(spark.history.kerberos.principal,none)\n",
+      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_HOSTS,soldier-master.fyre.ibm.com)\n",
+      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES,http://soldier-master.fyre.ibm.com:8088/proxy/application_1502395407456_0091)\n",
+      "(spark.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib/toree-launcher_2.11-1.0.jar)\n"
+     ]
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "sc.getConf.getAll.foreach(println)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - Scala (YARN Client Mode)",
+   "language": "scala",
+   "name": "spark_2.1_scala_yarn_client"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-scala",
+   "file_extension": ".scala",
+   "mimetype": "text/x-scala",
+   "name": "scala",
+   "pygments_lexer": "scala",
+   "version": "2.11.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
@@ -1,0 +1,389 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the application name and application ID with YARN RM web UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Waiting for a Spark session to start..."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8f6ef355-1491-4df1-83df-f24ceade34bd\n"
+     ]
+    }
+   ],
+   "source": [
+    "//DIFFERENT\n",
+    "println(sc.appName)\n",
+    "sc.applicationId"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the application config parameters with YARN RM web UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "conf = org.apache.spark.SparkConf@77d62788\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "org.apache.spark.SparkConf@77d62788"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "var conf = sc.getConf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "yarn\n",
+      "cluster\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(conf.get(\"spark.master\"))\n",
+    "println(conf.get(\"spark.submit.deployMode\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the host where the Kernel is running on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.16.213.83\n"
+     ]
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "println(conf.get(\"spark.driver.host\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add Jar magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Name: Compile Error\n",
+       "Message: <console>:27: error: object lwjgl is not a member of package org\n",
+       "       org.lwjgl.Version.getVersion()\n",
+       "           ^\n",
+       "\n",
+       "StackTrace: "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "// Will throw Compile Error\n",
+    "org.lwjgl.Version.getVersion()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The JAR file will be downloaded to the driver host, under path:\n",
+    "#### /hadoop/yarn/local/usercache/[username]/appcache/[appID]/[containerID]/tmp/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting download from https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar\n",
+      "Finished download of lwjgl-3.0.0b.jar\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "error: error while loading Encoders, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Encoders.class)' has location not matching its contents: contains class Encoders\n",
+       "error: error while loading RowFactory, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RowFactory.class)' has location not matching its contents: contains class RowFactory\n",
+       "error: error while loading AnalysisException, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/AnalysisException.class)' has location not matching its contents: contains class AnalysisException\n",
+       "error: error while loading functions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/functions.class)' has location not matching its contents: contains class functions\n",
+       "error: error while loading DataFrameStatFunctions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameStatFunctions.class)' has location not matching its contents: contains class DataFrameStatFunctions\n",
+       "error: error while loading ForeachWriter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/ForeachWriter.class)' has location not matching its contents: contains class ForeachWriter\n",
+       "error: error while loading SaveMode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/SaveMode.class)' has location not matching its contents: contains class SaveMode\n",
+       "error: error while loading RelationalGroupedDataset, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RelationalGroupedDataset.class)' has location not matching its contents: contains class RelationalGroupedDataset\n",
+       "error: error while loading DataFrameNaFunctions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameNaFunctions.class)' has location not matching its contents: contains class DataFrameNaFunctions\n",
+       "error: error while loading Column, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Column.class)' has location not matching its contents: contains class Column\n",
+       "error: error while loading TypedColumn, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/TypedColumn.class)' has location not matching its contents: contains class TypedColumn\n",
+       "error: error while loading KeyValueGroupedDataset, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/KeyValueGroupedDataset.class)' has location not matching its contents: contains class KeyValueGroupedDataset\n",
+       "error: error while loading DataFrameWriter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameWriter.class)' has location not matching its contents: contains class DataFrameWriter\n",
+       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-hive_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/hive/package.class)' has location not matching its contents: contains package object hive\n",
+       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/api/package.class)' has location not matching its contents: contains package object api\n",
+       "error: error while loading UnsafeExternalRowSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeExternalRowSorter.class)' has location not matching its contents: contains class UnsafeExternalRowSorter\n",
+       "error: error while loading UnsafeKeyValueSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKeyValueSorter.class)' has location not matching its contents: contains class UnsafeKeyValueSorter\n",
+       "error: error while loading CacheManager, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CacheManager.class)' has location not matching its contents: contains class CacheManager\n",
+       "error: error while loading PartitionIdPassthrough, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PartitionIdPassthrough.class)' has location not matching its contents: contains class PartitionIdPassthrough\n",
+       "error: error while loading SparkSqlAstBuilder, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlAstBuilder.class)' has location not matching its contents: contains class SparkSqlAstBuilder\n",
+       "error: error while loading MapPartitionsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapPartitionsExec.class)' has location not matching its contents: contains class MapPartitionsExec\n",
+       "error: error while loading ExpandExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExpandExec.class)' has location not matching its contents: contains class ExpandExec\n",
+       "error: error while loading UnaryExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnaryExecNode.class)' has location not matching its contents: contains class UnaryExecNode\n",
+       "error: error while loading SampleExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SampleExec.class)' has location not matching its contents: contains class SampleExec\n",
+       "error: error while loading ExternalRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDD.class)' has location not matching its contents: contains class ExternalRDD\n",
+       "error: error while loading LocalTableScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalTableScanExec.class)' has location not matching its contents: contains class LocalTableScanExec\n",
+       "error: error while loading LazyIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LazyIterator.class)' has location not matching its contents: contains class LazyIterator\n",
+       "error: error while loading InSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InSubquery.class)' has location not matching its contents: contains class InSubquery\n",
+       "error: error while loading SQLExecution, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SQLExecution.class)' has location not matching its contents: contains class SQLExecution\n",
+       "error: error while loading MapGroupsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapGroupsExec.class)' has location not matching its contents: contains class MapGroupsExec\n",
+       "error: error while loading SparkSqlParser, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlParser.class)' has location not matching its contents: contains class SparkSqlParser\n",
+       "error: error while loading CoGroupedIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupedIterator.class)' has location not matching its contents: contains class CoGroupedIterator\n",
+       "error: error while loading MapElementsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapElementsExec.class)' has location not matching its contents: contains class MapElementsExec\n",
+       "error: error while loading SparkPlan, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlan.class)' has location not matching its contents: contains class SparkPlan\n",
+       "error: error while loading FileRelation, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileRelation.class)' has location not matching its contents: contains class FileRelation\n",
+       "error: error while loading UnsafeFixedWidthAggregationMap, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.class)' has location not matching its contents: contains class UnsafeFixedWidthAggregationMap\n",
+       "error: error while loading LogicalRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LogicalRDD.class)' has location not matching its contents: contains class LogicalRDD\n",
+       "error: error while loading OutputFakerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OutputFakerExec.class)' has location not matching its contents: contains class OutputFakerExec\n",
+       "error: error while loading ShuffledRowRDDPartition, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDDPartition.class)' has location not matching its contents: contains class ShuffledRowRDDPartition\n",
+       "error: error while loading RowDataSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowDataSourceScanExec.class)' has location not matching its contents: contains class RowDataSourceScanExec\n",
+       "error: error while loading SparkPlanInfo, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanInfo.class)' has location not matching its contents: contains class SparkPlanInfo\n",
+       "error: error while loading BaseLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BaseLimitExec.class)' has location not matching its contents: contains class BaseLimitExec\n",
+       "error: error while loading WholeStageCodegenExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/WholeStageCodegenExec.class)' has location not matching its contents: contains class WholeStageCodegenExec\n",
+       "error: error while loading SortExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortExec.class)' has location not matching its contents: contains class SortExec\n",
+       "error: error while loading ObjectProducerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectProducerExec.class)' has location not matching its contents: contains class ObjectProducerExec\n",
+       "error: error while loading InputAdapter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InputAdapter.class)' has location not matching its contents: contains class InputAdapter\n",
+       "error: error while loading ScalarSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ScalarSubquery.class)' has location not matching its contents: contains class ScalarSubquery\n",
+       "error: error while loading FileSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileSourceScanExec.class)' has location not matching its contents: contains class FileSourceScanExec\n",
+       "error: error while loading ProjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ProjectExec.class)' has location not matching its contents: contains class ProjectExec\n",
+       "error: error while loading RowIteratorFromScala, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorFromScala.class)' has location not matching its contents: contains class RowIteratorFromScala\n",
+       "error: error while loading RowIteratorToScala, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorToScala.class)' has location not matching its contents: contains class RowIteratorToScala\n",
+       "error: error while loading ObjectOperator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectOperator.class)' has location not matching its contents: contains class ObjectOperator\n",
+       "error: error while loading PlanLater, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanLater.class)' has location not matching its contents: contains class PlanLater\n",
+       "error: error while loading RowIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIterator.class)' has location not matching its contents: contains class RowIterator\n",
+       "error: error while loading FlatMapGroupsInRExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FlatMapGroupsInRExec.class)' has location not matching its contents: contains class FlatMapGroupsInRExec\n",
+       "error: error while loading TakeOrderedAndProjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/TakeOrderedAndProjectExec.class)' has location not matching its contents: contains class TakeOrderedAndProjectExec\n",
+       "error: error while loading AppendColumnsWithObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsWithObjectExec.class)' has location not matching its contents: contains class AppendColumnsWithObjectExec\n",
+       "error: error while loading LocalLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalLimitExec.class)' has location not matching its contents: contains class LocalLimitExec\n",
+       "error: error while loading UnionExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnionExec.class)' has location not matching its contents: contains class UnionExec\n",
+       "error: error while loading PlanSubqueries, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanSubqueries.class)' has location not matching its contents: contains class PlanSubqueries\n",
+       "error: error while loading CodegenSupport, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CodegenSupport.class)' has location not matching its contents: contains class CodegenSupport\n",
+       "error: error while loading ObjectConsumerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectConsumerExec.class)' has location not matching its contents: contains class ObjectConsumerExec\n",
+       "error: error while loading CoalesceExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalesceExec.class)' has location not matching its contents: contains class CoalesceExec\n",
+       "error: error while loading ShuffledRowRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDD.class)' has location not matching its contents: contains class ShuffledRowRDD\n",
+       "error: error while loading SubqueryExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SubqueryExec.class)' has location not matching its contents: contains class SubqueryExec\n",
+       "error: error while loading GroupedIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GroupedIterator.class)' has location not matching its contents: contains class GroupedIterator\n",
+       "error: error while loading RDDConversions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDConversions.class)' has location not matching its contents: contains class RDDConversions\n",
+       "error: error while loading OptimizeMetadataOnlyQuery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.class)' has location not matching its contents: contains class OptimizeMetadataOnlyQuery\n",
+       "error: error while loading QueryExecution, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecution.class)' has location not matching its contents: contains class QueryExecution\n",
+       "error: error while loading LeafExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LeafExecNode.class)' has location not matching its contents: contains class LeafExecNode\n",
+       "error: error while loading CollapseCodegenStages, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollapseCodegenStages.class)' has location not matching its contents: contains class CollapseCodegenStages\n",
+       "error: error while loading QueryExecutionException, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecutionException.class)' has location not matching its contents: contains class QueryExecutionException\n",
+       "error: error while loading CoGroupExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupExec.class)' has location not matching its contents: contains class CoGroupExec\n",
+       "error: error while loading ExecSubqueryExpression, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExecSubqueryExpression.class)' has location not matching its contents: contains class ExecSubqueryExpression\n",
+       "error: error while loading BufferedRowIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BufferedRowIterator.class)' has location not matching its contents: contains class BufferedRowIterator\n",
+       "error: error while loading RDDScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDScanExec.class)' has location not matching its contents: contains class RDDScanExec\n",
+       "error: error while loading AppendColumnsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsExec.class)' has location not matching its contents: contains class AppendColumnsExec\n",
+       "error: error while loading DataSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DataSourceScanExec.class)' has location not matching its contents: contains class DataSourceScanExec\n",
+       "error: error while loading SerializeFromObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SerializeFromObjectExec.class)' has location not matching its contents: contains class SerializeFromObjectExec\n",
+       "error: error while loading ExternalRDDScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDDScanExec.class)' has location not matching its contents: contains class ExternalRDDScanExec\n",
+       "error: error while loading CoalescedPartitioner, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalescedPartitioner.class)' has location not matching its contents: contains class CoalescedPartitioner\n",
+       "error: error while loading UnsafeKVExternalSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKVExternalSorter.class)' has location not matching its contents: contains class UnsafeKVExternalSorter\n",
+       "error: error while loading SparkOptimizer, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkOptimizer.class)' has location not matching its contents: contains class SparkOptimizer\n",
+       "error: error while loading DeserializeToObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DeserializeToObjectExec.class)' has location not matching its contents: contains class DeserializeToObjectExec\n",
+       "error: error while loading SparkStrategies, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategies.class)' has location not matching its contents: contains class SparkStrategies\n",
+       "error: error while loading CollectLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollectLimitExec.class)' has location not matching its contents: contains class CollectLimitExec\n",
+       "error: error while loading RangeExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RangeExec.class)' has location not matching its contents: contains class RangeExec\n",
+       "error: error while loading ReuseSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ReuseSubquery.class)' has location not matching its contents: contains class ReuseSubquery\n",
+       "error: error while loading SparkStrategy, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategy.class)' has location not matching its contents: contains class SparkStrategy\n",
+       "error: error while loading GlobalLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GlobalLimitExec.class)' has location not matching its contents: contains class GlobalLimitExec\n",
+       "error: error while loading GenerateExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GenerateExec.class)' has location not matching its contents: contains class GenerateExec\n",
+       "error: error while loading UnsafeRowSerializer, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializer.class)' has location not matching its contents: contains class UnsafeRowSerializer\n",
+       "error: error while loading CachedData, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CachedData.class)' has location not matching its contents: contains class CachedData\n",
+       "error: error while loading SortPrefixUtils, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortPrefixUtils.class)' has location not matching its contents: contains class SortPrefixUtils\n",
+       "error: error while loading SparkPlanner, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanner.class)' has location not matching its contents: contains class SparkPlanner\n",
+       "error: error while loading BinaryExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BinaryExecNode.class)' has location not matching its contents: contains class BinaryExecNode\n",
+       "error: error while loading UnsafeRowSerializerInstance, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializerInstance.class)' has location not matching its contents: contains class UnsafeRowSerializerInstance\n",
+       "error: error while loading FilterExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FilterExec.class)' has location not matching its contents: contains class FilterExec\n",
+       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/joins/package.class)' has location not matching its contents: contains package object joins\n",
+       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/debug/package.class)' has location not matching its contents: contains package object debug\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "%addjar -f https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.0.0b SNAPSHOT"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "org.lwjgl.Version.getVersion()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(spark.history.kerberos.keytab,none)\n",
+      "(spark.eventLog.enabled,true)\n",
+      "(spark.app.id,application_1502395407456_0079)\n",
+      "(spark.submit.deployMode,cluster)\n",
+      "(spark.app.name,8f6ef355-1491-4df1-83df-f24ceade34bd)\n",
+      "(spark.yarn.submit.waitAppCompletion,false)\n",
+      "(spark.history.ui.port,18081)\n",
+      "(spark.driver.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
+      "(spark.executor.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
+      "(spark.repl.class.uri,spark://172.16.213.83:43772/classes)\n",
+      "(spark.repl.class.outputDir,/hadoop/yarn/local/usercache/elyra/appcache/application_1502395407456_0079/spark-c995b736-dd47-40aa-ab16-9a0dee598c56/repl-450f417a-f048-4a76-aa58-a0bc0c742b7f)\n",
+      "(spark.history.provider,org.apache.spark.deploy.history.FsHistoryProvider)\n",
+      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/lib/toree-assembly-luciano.jar)\n",
+      "(spark.ui.filters,org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter)\n",
+      "(spark.eventLog.dir,hdfs:///spark2-history/)\n",
+      "(spark.yarn.secondary.jars,toree-assembly-luciano.jar)\n",
+      "(spark.yarn.app.container.log.dir,/hadoop/yarn/log/application_1502395407456_0079/container_e01_1502395407456_0079_01_000001)\n",
+      "(spark.driver.host,172.16.213.83)\n",
+      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES,http://soldier-master.fyre.ibm.com:8088/proxy/application_1502395407456_0079)\n",
+      "(spark.yarn.historyServer.address,soldier-master.fyre.ibm.com:18081)\n",
+      "(spark.yarn.app.id,application_1502395407456_0079)\n",
+      "(spark.yarn.queue,default)\n",
+      "(spark.executor.id,driver)\n",
+      "(spark.history.fs.logDirectory,hdfs:///spark2-history/)\n",
+      "(spark.master,yarn)\n",
+      "(spark.ui.port,0)\n",
+      "(spark.history.kerberos.principal,none)\n",
+      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_HOSTS,soldier-master.fyre.ibm.com)\n",
+      "(spark.yarn.am.waitTime,1d)\n",
+      "(spark.driver.port,43772)\n",
+      "(hive.metastore.warehouse.dir,file:/hadoop/yarn/local/usercache/elyra/appcache/application_1502395407456_0079/container_e01_1502395407456_0079_01_000001/spark-warehouse)\n"
+     ]
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "sc.getConf.getAll.foreach(println)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark 2.1 - Scala (YARN Cluster Mode)",
+   "language": "scala",
+   "name": "spark_2.1_scala_yarn_cluster"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-scala",
+   "file_extension": ".scala",
+   "mimetype": "text/x-scala",
+   "name": "scala",
+   "pygments_lexer": "scala",
+   "version": "2.11.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -1,0 +1,95 @@
+from tornado.escape import json_encode, json_decode, url_escape
+from uuid import uuid4
+from nb_entity import NBCodeCell, NBCodeEntity
+import websocket
+from collections import deque
+
+import requests
+
+
+class ElyraClient(object):
+    execute_message = {
+        'header': {'username': '', 'version': '5.0', 'session': '', 'msg_id': "", 'msg_type': 'execute_request'},
+        'parent_header': {}, 'channel': 'shell', 'metadata': {}, 'buffers': {},
+        'content': {'silent': False, 'store_history': False, 'user_expressions': {}, 'allow_stdin': False}}
+
+    def __init__(self, host, username):
+        self.http_api_endpoint = "http://{}/api/kernels".format(host)
+        self.ws_endpoint = "ws://{}/api/kernels".format(host)
+        self.username = username
+
+    def delete_kernel(self, kernel_id):
+        if not kernel_id:
+            return False
+        url = "{}/{}".format(self.http_api_endpoint, kernel_id)
+        response = requests.delete(url)
+        return response.status_code == 204
+
+    def create_new_kernel(self, nb_code_entity):
+        # Ask Elyra to create a new kernel based on kernel spec name, and return the kernel id if successfully created.
+        kernel_id = None
+        kernel_spec_name = nb_code_entity.kernel_spec_name
+        file_name = nb_code_entity.file_name
+        response = requests.post(self.http_api_endpoint, data=json_encode({'name': kernel_spec_name, 'env' : {'KERNEL_USERNAME': self.username}}))
+        if response.status_code == 201:
+            json_data = response.json()
+            kernel_id = json_data.get("id")
+        return kernel_id
+
+    def get_ws_kernel_endpoint(self, kernel_id):
+        # Given a kernel id, return the corresponding web socket endpoint for this kernel to send/receive messages.
+        return "{}/{}/channels".format(self.ws_endpoint, url_escape(kernel_id))
+
+    @staticmethod
+    def new_code_message(code):
+        ElyraClient.execute_message["header"]["msg_id"] = uuid4().hex
+        ElyraClient.execute_message["content"]["code"] = code
+        return json_encode(ElyraClient.execute_message)
+
+    @staticmethod
+    def receive_target_messages(ws, target_msg_type_queue):
+        """
+        Given a web socket connection, after sending one message, we may receive multiple
+        messages back, e.g. status, execute_input, stream.
+        Here only find those target message type and return its content in a list.
+        """
+        message_json_list = list([])
+        while target_msg_type_queue:
+            try:
+                message = ws.recv()
+                message_json = json_decode(message)
+                msg_type = message_json.get('msg_type')
+                if msg_type == target_msg_type_queue[0]:
+                    target_msg_type_queue.popleft()  # find one target, remove from queue
+                    message_json_list.append(message_json)
+                if msg_type == "error":
+                    raise Exception("Error found when receiving message:\n{}".format(message_json))
+            except ValueError as e:
+                # Ignore No JSON object could be decoded error, continue to the next message.
+                if e.message == "No JSON object could be decoded":
+                    print(e.message)
+                    continue
+                else:
+                    raise e
+        return message_json_list
+
+    def execute_nb_code_entity(self, nb_code_entity):
+        # Execute all code cells in a notebook code entity, get the response message in JSON format,
+        # and return all code cells parsed by messages in a list.
+        ws = websocket.create_connection(self.get_ws_kernel_endpoint(nb_code_entity.kernel_id))
+        message_code_cell_list = list([])
+        try:
+            for code_cell in nb_code_entity.get_all_code_cell():
+                if code_cell.is_executed():
+                    code_source = code_cell.get_source_for_execution()
+                    ws.send(ElyraClient.new_code_message(code_source))
+                    target_queue = code_cell.get_target_output_type_queue()
+                    if code_cell.is_output_empty():
+                        # If output empty, waiting for "execute_input" type message
+                        target_queue = deque(["execute_input"])
+                    json_output_message = ElyraClient.receive_target_messages(ws, target_queue)
+                    msg_code_cell = NBCodeCell(message_json_list=json_output_message)
+                    message_code_cell_list.append(msg_code_cell)
+        finally:
+            ws.close()
+        return message_code_cell_list

--- a/enterprise_gateway/itests/src/itest_notebook.py
+++ b/enterprise_gateway/itests/src/itest_notebook.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+from elyra_client import ElyraClient
+import traceback
+import sys
+
+
+class NotebookTestCase(TestCase):
+
+    def __init__(self, test_method, nb_entities_list, continue_when_error, host, username):
+        TestCase.__init__(self, methodName=test_method)
+        self.nb_entities_list = nb_entities_list
+        self.continue_when_error = continue_when_error
+        self.elyra_client = ElyraClient(host=host, username=username)
+
+    @staticmethod
+    def get_assert_code(first_line_code):
+        """
+        Given the first line of the source code, return the code for testing purposes:
+        0 : must be exactly the same, i.e. using assertEqual (default)
+        1 : OK if test output not the same as input, i.e. ignore assert as long as no error
+        2 : must not be the same as each time the execution will definitely be different, then use assertNotEqual
+        """
+        if first_line_code:
+            if first_line_code.find("DIFFERENT") > 0:
+                return 1
+            elif first_line_code.find("DEPENDS") > 0:
+                return 2
+        return 0
+
+    def execute_codes(self, nb_code_entity):
+        nb_code_entity.kernel_id = self.elyra_client.create_new_kernel(nb_code_entity)
+        test_code_cell_output_list = None
+        if nb_code_entity.kernel_id:
+            try:
+                test_code_cell_output_list = self.elyra_client.execute_nb_code_entity(nb_code_entity)
+            except Exception as e:
+                print(e.message, traceback.format_exc())
+                if not self.continue_when_error:
+                    print("Failed to execute the codes, now exit.")
+                    sys.exit(-1)
+            finally:
+                self.elyra_client.delete_kernel(nb_code_entity.kernel_id)
+            return test_code_cell_output_list
+
+    def execute_and_assert(self, nb_code_entity):
+        print("Begin testing...({})".format(nb_code_entity))
+        test_code_cell_list = self.execute_codes(nb_code_entity)
+        self.assertIsNotNone(test_code_cell_list)
+        self.assertEqual(len(test_code_cell_list), len(nb_code_entity.code_cell_list))
+        index = 0
+        for real_code_cell in nb_code_entity.code_cell_list:
+            if real_code_cell.is_executed() and not real_code_cell.is_output_empty():
+                test_output = test_code_cell_list[index]
+                self.assertIsNotNone(test_output)
+                test_output = test_output.seralize_output()
+                real_output = real_code_cell.seralize_output()
+                assert_code = NotebookTestCase.get_assert_code(real_code_cell.get_first_line_code())
+                try:
+                    if assert_code == 0:
+                        self.assertEqual(test_output, real_output)
+                    elif assert_code == 1:
+                        self.assertNotEqual(test_output, real_output)
+                except Exception as e:
+                    print("===================================")
+                    print(e.message)
+                    print(traceback.format_exc())
+                    print("{}\nExecute count {}".format(nb_code_entity, real_code_cell.execute_count))
+                    print("[Test output]\n", test_output)
+                    print("[Real output]\n", real_output)
+                    if not self.continue_when_error:
+                        sys.exit(-1)
+            index += 1
+        print("Testing completed: ({})".format(nb_code_entity))
+
+
+    def test_kernels_batch(self):
+        print("Begin testing batch of {} notebooks...".format(len(self.nb_entities_list)))
+        for nb_code_entity in self.nb_entities_list:
+            self.execute_and_assert(nb_code_entity)
+        print("Batch completed.")

--- a/enterprise_gateway/itests/src/main.py
+++ b/enterprise_gateway/itests/src/main.py
@@ -1,0 +1,53 @@
+import sys
+import argparse
+import unittest
+import os
+from nb_entity import NBCodeEntity
+from itest_notebook import NotebookTestCase
+
+
+def parse_arg():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--target_kernels', default=None)
+    parser.add_argument('--notebook_files', default=None)
+    parser.add_argument('--notebook_dir', default='../notebooks')
+    parser.add_argument('--continue_when_error', default=True)
+    parser.add_argument('--host', default='localhost:8888')
+    parser.add_argument('--username', default='root')
+
+    return parser.parse_args()
+
+
+def init_nb_test_case(args):
+    target_kernels = None
+    if args.target_kernels is not None:
+        target_kernels = set(str(args.target_kernels).split(","))
+    nb_entities_list = list([])
+    if args.notebook_files is not None:
+        # If any target notebook_file is provided, test only those files
+        notebook_file_list = str(args.notebook_files).split(",")
+        for nb_file_path in notebook_file_list:
+            nb_entity = NBCodeEntity(nb_file_path)
+            if not target_kernels or nb_entity.kernel_spec_name in target_kernels:
+                nb_entities_list.append(nb_entity)
+    else:
+        # Otherwise, test all ipynb files in notebook_dir provided, and default is ../notebooks
+        for nb_file_path in os.listdir(args.notebook_dir):
+            if nb_file_path.endswith("pynb"):
+                nb_file_path = os.path.join(args.notebook_dir, nb_file_path)
+                nb_entity = NBCodeEntity(nb_file_path)
+                if not target_kernels or nb_entity.kernel_spec_name in target_kernels:
+                    nb_entities_list.append(nb_entity)
+
+    return NotebookTestCase(method, nb_entities_list, args.continue_when_error, args.host, args.username)
+
+
+if __name__ == '__main__':
+    args = parse_arg()
+    suite = unittest.TestSuite()
+    for method in dir(NotebookTestCase):
+        if method.startswith("test"):
+            suite.addTest(init_nb_test_case(args))
+
+    result = unittest.TextTestRunner().run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/enterprise_gateway/itests/src/nb_entity.py
+++ b/enterprise_gateway/itests/src/nb_entity.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+
+import os
+import json
+import sys
+from collections import deque
+
+# reload(sys)
+# sys.setdefaultencoding('utf8')
+
+
+class CodeCellOutput(object):
+    # A prototype class for the output of a cell whose type is "code"
+    def __init__(self, json_output, output_type):
+        self.raw_output = json_output
+        self.output_type = output_type
+        self.output = self.parse_output()
+
+    def parse_output(self):
+        # need different ways to parse the code_output format
+        raise NotImplementedError
+
+    @staticmethod
+    def build_code_cell(output_type, output):
+        if output_type == "stream":
+            return StreamOutput(json_output=output)
+        elif output_type == "execute_result":
+            return ExecuteResult(json_output=output)
+        elif output_type == "display_data":
+            return DisplayData(json_output=output)
+        elif output_type == "error":
+            return Error(json_output=output)
+        return None
+
+    def seralize(self):
+        if type(self.output) is dict:
+            for k, v in self.output.items():
+                if type(v) is list:
+                    v = "".join(v)
+                    self.output[k] = v
+        elif type(self.output) is list:
+            self.output = "".join(self.output)
+
+        output = "".join(self.output) if type(self.output) is list else self.output
+        return "{}:\n{}".format(self.__class__.__name__, output)
+
+
+class StreamOutput(CodeCellOutput):
+
+    def __init__(self, json_output):
+        CodeCellOutput.__init__(self, json_output, "stream")
+        self.name = self.raw_output.get("name")
+
+    def parse_output(self):
+        return self.raw_output.get("text")
+
+
+class DisplayData(CodeCellOutput):
+    def __init__(self, json_output):
+        CodeCellOutput.__init__(self, json_output, "display_data")
+
+    def parse_output(self):
+        return self.raw_output.get("data")
+
+
+class ExecuteResult(CodeCellOutput):
+    def __init__(self, json_output):
+        CodeCellOutput.__init__(self, json_output, "execute_result")
+
+    def parse_output(self):
+        return self.raw_output.get("data")
+
+
+class Error(CodeCellOutput):
+    def __init__(self, json_output):
+        CodeCellOutput.__init__(self, json_output, "error")
+        self.ename = self.evalue = self.traceback = None
+
+    def parse_output(self):
+        self.ename = self.raw_output.get("ename")
+        self.evalue = self.raw_output.get("evalue")
+        self.traceback = self.raw_output.get("traceback")
+        return "{}\n{}\n{}".format(self.ename, self.evalue, self.traceback)
+
+
+class NBCodeCell(object):
+    # An object represent a code cell in a notebook .ipynb file.
+    # May contain different types of code outputs, e.g. stream, display data
+    def __init__(self, cell_json=None, message_json_list=None):
+        self.code_source_list = list([])
+        self.code_output_list = list([])
+        self.execute_count = None
+        if cell_json:
+            self.code_source_list = cell_json.get("source")
+            self.execute_count = cell_json.get("execution_count")
+            self.code_output_list = NBCodeCell.parse_output_from_notebook(cell_json)
+        elif message_json_list:
+            self.code_output_list = NBCodeCell.parse_output_from_message(message_json_list)
+
+    def is_executed(self):
+        # Check if this code is literally executed
+        return self.execute_count is not None
+
+    def get_source_for_execution(self):
+        # The cell's source can have multiple lines of codes, but here return the source as a single string,
+        # since executing a multi-line code v.s. line by line may generate different results.
+        return "".join(self.code_source_list)
+
+    def is_output_empty(self):
+        # Check if a cell has any output in it, as in some cases, the code cell output can be empty,
+        # e.g. define a function/class or import a package.
+        for output in self.code_output_list:
+            if output:
+                return False
+        return True
+
+    def get_first_line_code(self):
+        first_line = self.code_source_list[0] if self.code_source_list else None
+        return str(first_line).upper()
+
+    def get_target_output_type_queue(self):
+        # Return all output types as a queue, FIFO
+        target_output_type_queue = deque([])
+        for co in self.code_output_list:
+            target_output_type_queue.append(co.output_type)
+        return target_output_type_queue
+
+    def __repr__(self):
+        return "Execution_count {}, {} lines of codes, {} outputs".format(
+            self.execute_count, len(self.code_source_list), len(self.code_output_list))
+
+    @staticmethod
+    def parse_output_from_notebook(nb_cell_json):
+        # Build a list of code cell output entity from notebook json file,
+        # since a code cell in notebook json file can have multiple output.
+        cell_output_list = list([])
+        if nb_cell_json and type(nb_cell_json) is dict:
+            if nb_cell_json.get("cell_type") == "code" and "outputs" in nb_cell_json:
+                json_output_list = nb_cell_json.get("outputs")
+                for output in json_output_list:
+                    cell_output = CodeCellOutput.build_code_cell(output.get("output_type"), output)
+                    cell_output_list.append(cell_output)
+        return cell_output_list
+
+    @staticmethod
+    def parse_output_from_message(message_json_list):
+        # Build a list of code cell output from a list of json message received from socket
+        cell_output_list = list([])
+        if message_json_list:
+            for message_json in message_json_list:
+                cell_output = CodeCellOutput.build_code_cell(message_json.get("msg_type"), message_json.get("content"))
+                cell_output_list.append(cell_output)
+        return cell_output_list
+
+    def seralize_output(self):
+        if self is not None:
+            str_list = []
+            for code_cell_output in self.code_output_list:
+                if code_cell_output:
+                    str_list.append(code_cell_output.seralize())
+            return "".join(str_list)
+        return "No output"
+
+
+class NBCodeEntity(object):
+    # An object represent all code cells inside a NB
+
+    def __init__(self, nb_file_path):
+        self.nb_file_path = nb_file_path
+        self.kernel_id = None
+        if os.path.exists(nb_file_path):
+            self.file_name = os.path.split(nb_file_path)[1]
+            nb_file = open(nb_file_path, mode='r')
+            nb_json = json.load(fp=nb_file)
+            self.code_cell_list = list([])
+            kernel_spec = nb_json["metadata"]["kernelspec"]
+            self.kernel_spec_name = kernel_spec["name"]
+            for cell in nb_json.get("cells"):
+                if cell.get("cell_type") == "code":
+                    code_cell = NBCodeCell(cell_json=cell)
+                    self.code_cell_list.append(code_cell)
+            nb_file.close()
+        else:
+            raise IOError("No such file provided: {}".format(nb_file_path))
+
+    def get_all_code_cell(self):
+        return self.code_cell_list
+
+    def get_all_code_cell_output(self):
+        res_list = list([])
+        for code_cell in self.code_cell_list:
+            for output in code_cell.code_output_list:
+                res_list.append(output)
+        return res_list
+
+    def __repr__(self):
+        return "Kernel ID: {}, Notebook: {}, Kernel spec: {}, Number of code cells: {}".\
+            format(self.kernel_id, self.file_name, self.kernel_spec_name, len(self.code_cell_list))

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -43,6 +43,10 @@ RUN ssh-keygen -q -N "" -t rsa -f /home/elyra/.ssh/id_rsa && \
 
 USER root
 
+ADD ssh_config /home/elyra/.ssh/config
+RUN chmod 600 /home/elyra/.ssh/config && \
+    chown elyra:elyra /home/elyra/.ssh/config
+
 # install boot script 
 COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh
 RUN chown root.root /etc/bootstrap-enterprise-gateway.sh && \

--- a/etc/docker/enterprise-gateway/bootstrap-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/bootstrap-enterprise-gateway.sh
@@ -42,7 +42,7 @@ cp $SPARK_HOME/conf/metrics.properties.template $SPARK_HOME/conf/metrics.propert
 
 service rsyslog start
 service rsyslog status
-service sshd start
+service sshd restart
 service sshd status
 $HADOOP_PREFIX/sbin/start-dfs.sh
 $HADOOP_PREFIX/sbin/start-yarn.sh

--- a/etc/docker/enterprise-gateway/ssh_config
+++ b/etc/docker/enterprise-gateway/ssh_config
@@ -1,0 +1,5 @@
+Host *
+  UserKnownHostsFile /dev/null
+  StrictHostKeyChecking no
+  LogLevel quiet
+  Port 2122

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 nose
 mock
+websocket-client


### PR DESCRIPTION
Initial checkin of integration tests.  Updated tests to be python 3
compatible and added some print statements for improved status monitoring.

`make itest` will run integration tests against an updated enterprise-gateway
docker image. If you want to run the integration tests against a regular server,
use `make PREP_DOCKER=0 itest`.

At this time, only the python notebooks appear to be completing successfully.
As a result, the makefile is configured to run only those notebooks via the
`ITEST_OPTIONS` variable.  Makefile variables `ITEST_HOST`, `ITEST_USER` and
`ITEST_OPTIONS` can be used to change test targets and behaviors.

Updated ssh-config and added restart of sshd in the EG docker image to make
tests run more reliably.

Resolves #28 & #29