### PR TITLE
[HOTFIX] Fix Makefile dependency on bdist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ install: ## Make a conda env with dist/*.whl and dist/*.tar.gz installed
 	conda env remove -y -n $(ENV)-install
 
 bdist: ## Make a dist/*.whl binary distribution
+	make $(WHEEL_FILE)
 
 $(WHEEL_FILE): $(WHEEL_FILES)
 	$(SA) $(ENV) && python setup.py bdist_wheel $(POST_SDIST) \


### PR DESCRIPTION
A last minute modification to the previous commit wound up breaking
the dependencies for the `bdist` target.  This addresses that issue.