### PR TITLE
Use separate log files for remote kernels

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -246,10 +246,9 @@ JupyterWebsocketPersonality options
       is enabled (True) or not (False).  This feature is currently in experimental 
       stages but we intend to flip the default value to True at some point.  
         
-  EG_PROXY_LAUNCH_LOG=/tmp/jeg_proxy_launch.log 
-      The log file used during remote kernel launches of DistributedProcessProxy
-      based kernels.  This file should be consulted when kernel operations are not 
-      working as expected.  Note that it will contain output from multiple kernels.  
+  EG_KERNEL_LOG_DIR=/tmp 
+      The directory used during remote kernel launches of DistributedProcessProxy
+      kernels.  Files in this directory will be of the form kernel-<kernel_id>.log.  
               
   EG_KERNEL_LAUNCH_TIMEOUT=30 
       The time (in seconds) Enterprise Gateway will wait for a kernel's startup 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -56,9 +56,9 @@ a "Kernel error" and an `AuthenticationException`.**
     ```
 
 
- In general, you can look for more information in the proxy launch log for YARN Client 
- kernels.  The default location is /tmp/jeg_proxy_launch.log and it can be configured 
- using the environment variable `EG_PROXY_LAUNCH_LOG` during Enterprise Gateway start up. 
+ In general, you can look for more information in the kernel log for YARN Client 
+ kernels.  The default location is /tmp with a filename of `kernel-<kernel_id>.log`.  The location 
+ can be configured using the environment variable `EG_KERNEL_LOG_DIR` during Enterprise Gateway start up. 
  
  See [Starting Enterprise Gateway](getting-started.html#starting-enterprise-gateway) for an 
  example of starting the Enterprise Gateway from a script and 

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -11,7 +11,7 @@ from socket import *
 from .processproxy import RemoteProcessProxy
 
 poll_interval = float(os.getenv('EG_POLL_INTERVAL', '0.5'))
-proxy_launch_log = os.getenv('EG_PROXY_LAUNCH_LOG', '/tmp/jeg_proxy_launch.log')
+kernel_log_dir = os.getenv("EG_KERNEL_LOG_DIR", '/tmp')  # would prefer /var/log, but its only writable by root
 
 
 class DistributedProcessProxy(RemoteProcessProxy):
@@ -78,7 +78,8 @@ class DistributedProcessProxy(RemoteProcessProxy):
         for arg in argv_cmd:
             cmd += ' {}'.format(arg)
 
-        cmd += ' >> {} 2>&1 & echo $!'.format(proxy_launch_log)
+        kernel_log = os.path.join(kernel_log_dir, "kernel-{}.log".format(kid))
+        cmd += ' >> {} 2>&1 & echo $!'.format(kernel_log)
 
         return cmd
 


### PR DESCRIPTION
Previously, Enterprise Gateway used a single log file specified by
`EG_PROXY_LAUNCH_LOG` to capture output from remote kernels.  This
produced mixed entries for different kernels running on that particular
node.

This change creates a separate file for each remote kernel launched
via the DistributedProcessProxy.  The environment variable `EG_PROXY_LAUNCH_LOG`
has been replaced with `EG_KERNEL_LOG_DIR` which still defaults to `/tmp` as
the file location.  (Note: use of `/var/log` as the default is problematic
because its only writable by `root`.)  The format of the filename will be
`kernel-<kernel_id>.log`, which follows the same format as the default
connection file information - `kernel-<kernel_id>.json`.

The applicable locations in the online docs have also been modified.

Fixes #221