### PR TITLE
Remove spark version indicator from kernelspecs

### DIFF
--- a/docs/source/getting-started-client-mode.md
+++ b/docs/source/getting-started-client-mode.md
@@ -32,7 +32,7 @@ For each supported Jupyter Kernel, we have provided sample kernel configurations
 [e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
 
 Considering we would like to enable the iPython Kernel that comes pre-installed with Anaconda to run on
-Yarn Client mode, we would have to copy the sample configuration folder **spark_2.1_python_yarn_client**
+Yarn Client mode, we would have to copy the sample configuration folder **spark_python_yarn_client**
 to where the Jupyter kernels are installed (e.g. jupyter kernelspec list)
 
 ``` Bash
@@ -42,7 +42,7 @@ SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "python3" | awk '{print $2
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_python_yarn_client/ spark_2.1_python_yarn_client/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 
 ```
 
@@ -51,7 +51,7 @@ After that, you should have a kernel.json that looks similar to the one below:
 ```json
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Client Mode)",
+  "display_name": "Spark - Python (YARN Client Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
@@ -64,7 +64,7 @@ After that, you should have a kernel.json that looks similar to the one below:
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"
@@ -85,7 +85,7 @@ Please see below how a kernel.json would look like for integrating with Spark St
 ```json
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Client Mode)",
+  "display_name": "Spark - Python (YARN Client Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
@@ -98,7 +98,7 @@ Please see below how a kernel.json would look like for integrating with Spark St
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -23,7 +23,7 @@ For each supported Jupyter Kernel, we have provided sample kernel configurations
 [e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
 
 Considering we would like to enable the iPython Kernel that comes pre-installed with Anaconda to run on Yarn Cluster mode, we
-would have to copy the sample configuration folder **spark_2.1_python_yarn_cluster** to where the Jupyter kernels are installed 
+would have to copy the sample configuration folder **spark_python_yarn_cluster** to where the Jupyter kernels are installed 
 (e.g. jupyter kernelspec list)
 
 ``` Bash
@@ -33,7 +33,7 @@ SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "python3" | awk '{print $2
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_python_yarn_cluster/ spark_2.1_python_yarn_cluster/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 
 ```
 
@@ -42,7 +42,7 @@ After that, you should have a kernel.json that looks similar to the one below:
 ```json
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+  "display_name": "Spark - Python (YARN Cluster Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
   },
@@ -55,7 +55,7 @@ After that, you should have a kernel.json that looks similar to the one below:
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/docs/source/getting-started-kernels.md
+++ b/docs/source/getting-started-kernels.md
@@ -30,25 +30,25 @@ jupyter toree install --spark_home="${SPARK_HOME}" --kernel_name="Spark 2.1" --i
 **Update the Apache Toree Kernelspecs**
 
 we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
+[e.g. jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
 
 Considering we would like to enable the Scala Kernel to run on YARN Cluster and Client mode
-we would have to copy the sample configuration folder **spark_2.1_scala_yarn_client** and
-**spark_2.1_scala_yarn_client** to where the Jupyter kernels are installed
+we would have to copy the sample configuration folder **spark_scala_yarn_client** and
+**spark_scala_yarn_client** to where the Jupyter kernels are installed
 (e.g. jupyter kernelspec list)
 
 ``` Bash
 wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
 
-SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_2.1_scala" | awk '{print $2}')"
+SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_scala_yarn_cluster/ spark_2.1_scala_yarn_cluster/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_scala_yarn_client/ spark_2.1_scala_yarn_client/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
 
-cp $KERNELS_FOLDER/spark_2.1_scala/lib/*.jar  $KERNELS_FOLDER/spark_2.1_scala_yarn_cluster/lib
+cp $KERNELS_FOLDER/spark_scala/lib/*.jar  $KERNELS_FOLDER/spark_scala_yarn_cluster/lib
 ```
 
 For more information about the Scala kernel, please visit the [Apache Toree](http://toree.apache.org/) page.
@@ -63,23 +63,23 @@ The IPython kernel comes pre-installed with Anaconda and we have tested with its
 **Update the iPython Kernelspecs**
 
 we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
+[e.g. jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz).
 
 Considering we would like to enable the iPython kernel to run on YARN Cluster and Client mode
-we would have to copy the sample configuration folder **spark_2.1_python_yarn_client** and
-**spark_2.1_python_yarn_client** to where the Jupyter kernels are installed
+we would have to copy the sample configuration folder **spark_python_yarn_client** and
+**spark_python_yarn_client** to where the Jupyter kernels are installed
 (e.g. jupyter kernelspec list)
 
 ``` Bash
 wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
 
-SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_2.1_scala" | awk '{print $2}')"
+SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_python_yarn_cluster/ spark_2.1_python_yarn_cluster/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_2.1_python_yarn_client/ spark_2.1_python_yarn_client/
+tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 ```
 
 For more information about the iPython kernel, please visit the [iPython kernel](http://ipython.readthedocs.io/en/stable/) page.

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -53,7 +53,7 @@ Here's an example of a kernel specification that uses the `DistributedProcessPro
 ```json
 {
   "language": "scala",
-  "display_name": "Spark 2.1 - Scala (YARN Client Mode)",
+  "display_name": "Spark - Scala (YARN Client Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
@@ -65,7 +65,7 @@ Here's an example of a kernel specification that uses the `DistributedProcessPro
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_scala_yarn_client/bin/run.sh",
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
@@ -259,13 +259,13 @@ argument name.  However, the response address is identified by the parameter `--
 value (`{response_address}`) consists of a string of the form `<IPV4:port>` where the IPV4 address points 
 back to the Enterprise Gateway server - which is listening for a response on the provided port.
 
-Here's a [kernel.json](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/kernel.json) 
+Here's a [kernel.json](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_python_yarn_cluster/kernel.json) 
 file illustrating these parameters...
 
 ```json
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+  "display_name": "Spark - Python (YARN Cluster Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
   },
@@ -275,7 +275,7 @@ file illustrating these parameters...
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"
@@ -284,7 +284,7 @@ file illustrating these parameters...
 ```
 Kernel.json files also include a `LAUNCH_OPTS:` section in the `env` stanza to allow for custom 
 parameters to be conveyed in the launcher's environment.  `LAUNCH_OPTS` are then referenced in 
-the [run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_2.1_python_yarn_cluster/bin/run.sh) 
+the [run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh) 
 script as the initial arguments to the launcher 
 (see [launch_ipykernel.py](https://github.com/jupyter-incubator/enterprise_gateway/blob/enterprise_gateway/etc/kernel-launchers/python/scripts/launch_ipykernel.py)) ...
 ```bash

--- a/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
@@ -148,9 +148,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - Python (YARN Client Mode)",
+   "display_name": "Spark - Python (YARN Client Mode)",
    "language": "python",
-   "name": "spark_2.1_python_yarn_client"
+   "name": "spark_python_yarn_client"
   },
   "language_info": {
    "codemirror_mode": {

--- a/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
@@ -148,9 +148,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+   "display_name": "Spark - Python (YARN Cluster Mode)",
    "language": "python",
-   "name": "spark_2.1_python_yarn_cluster"
+   "name": "spark_python_yarn_cluster"
   },
   "language_info": {
    "codemirror_mode": {

--- a/enterprise_gateway/itests/notebooks/R_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Client1.ipynb
@@ -894,9 +894,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - R (YARN Client Mode)",
+   "display_name": "Spark - R (YARN Client Mode)",
    "language": "R",
-   "name": "spark_2.1_r_yarn_client"
+   "name": "spark_r_yarn_client"
   },
   "language_info": {
    "codemirror_mode": "r",

--- a/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
@@ -639,9 +639,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - R (YARN Cluster Mode)",
+   "display_name": "Spark - R (YARN Cluster Mode)",
    "language": "R",
-   "name": "spark_2.1_r_yarn_cluster"
+   "name": "spark_r_yarn_cluster"
   },
   "language_info": {
    "codemirror_mode": "r",

--- a/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
@@ -365,7 +365,7 @@
       "(spark.eventLog.dir,hdfs:///spark2-history/)\n",
       "(spark.driver.host,172.16.210.224)\n",
       "(spark.yarn.historyServer.address,soldier-master.fyre.ibm.com:18081)\n",
-      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib/toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
+      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib/toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
       "(spark.yarn.secondary.jars,toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
       "(spark.yarn.queue,default)\n",
       "(spark.executor.id,driver)\n",
@@ -377,7 +377,7 @@
       "(spark.history.kerberos.principal,none)\n",
       "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_HOSTS,soldier-master.fyre.ibm.com)\n",
       "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES,http://soldier-master.fyre.ibm.com:8088/proxy/application_1502395407456_0091)\n",
-      "(spark.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib/toree-launcher_2.11-1.0.jar)\n"
+      "(spark.jars,file:/usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib/toree-launcher_2.11-0.7.0.SNAPSHOT.jar)\n"
      ]
     }
    ],
@@ -389,9 +389,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - Scala (YARN Client Mode)",
+   "display_name": "Spark - Scala (YARN Client Mode)",
    "language": "scala",
-   "name": "spark_2.1_scala_yarn_client"
+   "name": "spark_scala_yarn_client"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",

--- a/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
@@ -371,9 +371,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Spark 2.1 - Scala (YARN Cluster Mode)",
+   "display_name": "Spark - Scala (YARN Cluster Mode)",
    "language": "scala",
-   "name": "spark_2.1_scala_yarn_cluster"
+   "name": "spark_scala_yarn_cluster"
   },
   "language_info": {
    "codemirror_mode": "text/x-scala",

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -14,11 +14,11 @@ ADD start-enterprise-gateway.sh.template /usr/local/share/jupyter
 # Add YARN_CONF_DIR to each env stanza, Add PATH to R-yarn-client env stanza
 RUN mkdir -p /usr/hdp/current && \
 	ln -s /usr/local/spark-2.1.0-bin-hadoop2.7 /usr/hdp/current/spark2-client && \
-	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/lib && \
-	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/lib && \
+	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/lib && \
+	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib && \
 	cd /usr/local/share/jupyter/kernels && \
-	for dir in spark_2.1_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
-	cat spark_2.1_R_yarn_client/kernel.json | sed s/'"env": {'/'"env": {|    "PATH": "\/opt\/anaconda2\/bin:$PATH",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_2.1_R_yarn_client/kernel.json && \
+	for dir in spark_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
+	cat spark_R_yarn_client/kernel.json | sed s/'"env": {'/'"env": {|    "PATH": "\/opt\/anaconda2\/bin:$PATH",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_R_yarn_client/kernel.json && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
 	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
 

--- a/etc/kernelspecs/spark_R_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_R_yarn_client/bin/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-echo
-echo "Starting IPython kernel for Spark 2.1 in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
-
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
+
+echo
+echo "Starting IRkernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
@@ -15,7 +15,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
-     "${PROG_HOME}/scripts/launch_ipykernel.py" \
+     "${PROG_HOME}/scripts/launch_IRkernel.R" \
      "${LAUNCH_OPTS}" \
      "$@"
 set +x

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -1,6 +1,6 @@
 {
   "language": "R",
-  "display_name": "Spark 2.1 - R (YARN Client Mode)",
+  "display_name": "Spark - R (YARN Client Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
@@ -11,7 +11,7 @@
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_R_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/etc/kernelspecs/spark_R_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_R_yarn_cluster/bin/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-echo
-echo "Starting IPython kernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
-
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
+
+echo
+echo "Starting IRkernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
@@ -15,7 +15,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
-     "${PROG_HOME}/scripts/launch_ipykernel.py" \
+     "${PROG_HOME}/scripts/launch_IRkernel.R" \
      "${LAUNCH_OPTS}" \
      "$@"
 set +x

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -1,6 +1,6 @@
 {
   "language": "R",
-  "display_name": "Spark 2.1 - R (YARN Cluster Mode)",
+  "display_name": "Spark - R (YARN Cluster Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
   },
@@ -11,7 +11,7 @@
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_cluster/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_R_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/etc/kernelspecs/spark_python_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_python_yarn_client/bin/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
+echo
+echo "Starting IPython kernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
+
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
-
-echo
-echo "Starting IRkernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
@@ -15,7 +15,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
-     "${PROG_HOME}/scripts/launch_IRkernel.R" \
+     "${PROG_HOME}/scripts/launch_ipykernel.py" \
      "${LAUNCH_OPTS}" \
      "$@"
 set +x

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -1,19 +1,19 @@
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+  "display_name": "Spark - Python (YARN Client Mode)",
   "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
     "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip,PATH=/opt/anaconda2/bin:$PATH",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
+    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
+echo
+echo "Starting IPython kernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
+
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
-
-echo
-echo "Starting IRkernel for Spark 2.1 in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
@@ -15,7 +15,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
-     "${PROG_HOME}/scripts/launch_IRkernel.R" \
+     "${PROG_HOME}/scripts/launch_ipykernel.py" \
      "${LAUNCH_OPTS}" \
      "$@"
 set +x

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -1,19 +1,19 @@
 {
   "language": "python",
-  "display_name": "Spark 2.1 - Python (YARN Client Mode)",
+  "display_name": "Spark - Python (YARN Cluster Mode)",
   "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
     "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip,PATH=/opt/anaconda2/bin:$PATH",
-    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_python_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}"

--- a/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo
-echo "Starting Scala kernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting Scala kernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then

--- a/etc/kernelspecs/spark_scala_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_client/kernel.json
@@ -1,6 +1,6 @@
 {
   "language": "scala",
-  "display_name": "Spark 2.1 - Scala (YARN Client Mode)",
+  "display_name": "Spark - Scala (YARN Client Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
   },
@@ -14,7 +14,7 @@
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_scala_yarn_client/bin/run.sh",
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",

--- a/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo
-echo "Starting Scala kernel for Spark 2.1 in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting Scala kernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -1,6 +1,6 @@
 {
   "language": "scala",
-  "display_name": "Spark 2.1 - Scala (YARN Cluster Mode)",
+  "display_name": "Spark - Scala (YARN Cluster Mode)",
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
   },
@@ -15,7 +15,7 @@
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [
-    "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/bin/run.sh",
+    "/usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/bin/run.sh",
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",


### PR DESCRIPTION
Removed references to the spark version (`2.1`) from the kernelspecs (display
names and echo statements), renamed directories accordingly, and updated like
references in the docs.

Also, updated the doc reference to the `0.6.0` version of the kernelspecs tar
file to `0.7.0` since we will be cutting a release later this week.  As a result,
there may be a brief window where that corresponding link is invalid.

Fixes #174