### PR TITLE
Restore test test_default_kernel_name

### DIFF
--- a/enterprise_gateway/tests/test_jupyter_websocket.py
+++ b/enterprise_gateway/tests/test_jupyter_websocket.py
@@ -551,10 +551,6 @@ class TestDefaults(TestJupyterWebsocket):
             ws.close()
 
 
-# This test is currently skipped until https://github.com/jupyter/notebook/issues/2942 is
-# resolved or addressed.  At this moment, the response.body only contains the following:
-# '{"reason": "Internal Server Error", "message": ""}'
-@unittest.skip
 class TestCustomDefaultKernel(TestJupyterWebsocket):
     """Tests gateway behavior when setting a custom default kernelspec."""
     def setup_app(self):


### PR DESCRIPTION
Restored `test_default_kernel_name` since `jupyter-kernel-gateway 2.0.2`
is now available on pypi and contains the necessary fix to enable
this test's proper behavior.

Fixes #188