### PR TITLE
[HOTFIX] Fix broken link to kernelspecs tar file.

### DIFF
--- a/docs/source/getting-started-kernels.md
+++ b/docs/source/getting-started-kernels.md
@@ -7,6 +7,10 @@ The following kernels have been tested with the Jupyter Enterprise Gateway:
 * Scala 2.11/Apache Spark 2.x with Apache Toree kernel
 * R/Apache Spark 2.x with IRkernel
 
+We provide sample kernel configuration and launcher tar files as part of [each release](https://github.com/jupyter-incubator/enterprise_gateway/releases)
+(e.g. [jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz))
+that can be extracted and modified to fit your configuration.
+
 Please find below more details on specific kernels:
 
 ### Scala kernel (Apache Toree kernel)
@@ -29,24 +33,21 @@ jupyter toree install --spark_home="${SPARK_HOME}" --kernel_name="Spark 2.1" --i
 
 **Update the Apache Toree Kernelspecs**
 
-we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
-
 Considering we would like to enable the Scala Kernel to run on YARN Cluster and Client mode
 we would have to copy the sample configuration folder **spark_scala_yarn_client** and
 **spark_scala_yarn_client** to where the Jupyter kernels are installed
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
 
 cp $KERNELS_FOLDER/spark_scala/lib/*.jar  $KERNELS_FOLDER/spark_scala_yarn_cluster/lib
 ```
@@ -62,24 +63,21 @@ The IPython kernel comes pre-installed with Anaconda and we have tested with its
 
 **Update the iPython Kernelspecs**
 
-we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz).
-
 Considering we would like to enable the iPython kernel to run on YARN Cluster and Client mode
 we would have to copy the sample configuration folder **spark_python_yarn_client** and
 **spark_python_yarn_client** to where the Jupyter kernels are installed
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 
-tar -zxvf enterprise_gateway_kernelspecs.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 ```
 
 For more information about the iPython kernel, please visit the [iPython kernel](http://ipython.readthedocs.io/en/stable/) page.
@@ -111,3 +109,23 @@ $ANACONDA_HOME/bin/Rscript install_packages.R
 # OPTIONAL: check the installed R packages
 ls $ANACONDA_HOME/lib/R/library
 ```
+**Update the iR Kernelspecs**
+
+Considering we would like to enable the iR kernel to run on YARN Cluster and Client mode
+we would have to copy the sample configuration folder **spark_R_yarn_client** and
+**spark_R_yarn_client** to where the Jupyter kernels are installed
+(e.g. jupyter kernelspec list)
+
+``` Bash
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
+
+SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
+
+KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
+
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_cluster/ spark_R_yarn_cluster/
+
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
+```
+
+For more information about the iR kernel, please visit the [iR kernel](https://irkernel.github.io/) page.


### PR DESCRIPTION
Fixed the broken link to kernelspec tar file. However, while on this
page I discovered the need for the following changes.

1. We had duplicate statements for Scala and Python sections so I moved
to the beginning section where all three kernels are referenced.
2. Both code blocks for Scala and Python instructions referenced invalid
links to 0.6 and then used referenced invalid tar files.  With the changes,
they *should* be able to cut/paste the instructions.
3. We were missing the comparable section for the iR kernel - so I added it.

Fixes #229