### PR TITLE
Add initial authorization and impersonation support

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -118,6 +118,14 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.auth_token=<Unicode>
     Default: u''
     Authorization token required for all requests (KG_AUTH_TOKEN env var)
+--EnterpriseGatewayApp.authorized_users=<Set>
+    Default: set([])
+    Comma-separated list of user names (e.g., ['bob','alice']) against which
+    KERNEL_USERNAME will be compared.  Any match (case-sensitive) will allow the
+    kernel's launch, otherwise an HTTP 403 (Forbidden) error will be raised.
+    The set of unauthorized users takes precedence. This option should be used
+    carefully as it can dramatically limit who can launch kernels.
+    (EG_AUTHORIZED_USERS env var - non-bracketed, just comma-separated)
 --EnterpriseGatewayApp.base_url=<Unicode>
     Default: '/'
     The base path for mounting all API resources (KG_BASE_URL env var)
@@ -147,6 +155,10 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.generate_config=<Bool>
     Default: False
     Generate default config file.
+--EnterpriseGatewayApp.impersonation_enabled=<Bool>
+    Default: False
+    Indicates whether impersonation will be performed during kernel launch.
+    (EG_IMPERSONATION_ENABLED env var)
 --EnterpriseGatewayApp.ip=<Unicode>
     Default: '127.0.0.1'
     IP address on which to listen (KG_IP env var)
@@ -191,6 +203,12 @@ EnterpriseGatewayApp options
     Default: None
     Runs the notebook (.ipynb) at the given URI on every kernel launched. No
     seed by default. (KG_SEED_URI env var)
+--EnterpriseGatewayApp.unauthorized_users=<Set>
+    Default: set(['root'])
+    Comma-separated list of user names (e.g., ['root','admin']) against which
+    KERNEL_USERNAME will be compared.  Any match (case-sensitive) will prevent
+    the kernel's launch and result in an HTTP 403 (Forbidden) error.
+    (EG_UNAUTHORIZED_USERS env var - non-bracketed, just comma-separated)
 --EnterpriseGatewayApp.yarn_endpoint=<Unicode>
     Default: 'http://localhost:8088/ws/v1/cluster'
     The http url for accessing the YARN Resource Manager. (EG_YARN_ENDPOINT env
@@ -228,23 +246,11 @@ JupyterWebsocketPersonality options
     by default but kernel gateway does not.
 ```
 
-### Supported environment variables
+### Addtional supported environment variables
 ```
-  EG_YARN_ENDPOINT=http://localhost:8088/ws/v1/cluster 
-      YARN resource manager endpoint.  This value can also be specified on the 
-      command line via option '--EnterpriseGatewayApp.yarn_endpoint'.  
-
-  EG_REMOTE_HOSTS=localhost 
-      A comma-separated list of hosts on which DistributedProcessProxy kernels will
-      be launched e.g., host1,host2.  Not bracketing or quoting of hostnames is 
-      required when setting the env variable.  This value can also be specified on 
-      the command line via option '--EnterpriseGatewayApp.remote_hosts', although 
-      bracketing and quoting is required in that case.  
- 
-  EG_ENABLE_TUNNELING=False 
+  EG_ENABLE_TUNNELING=True 
       Indicates whether tunneling (via ssh) of the kernel and communication ports
-      is enabled (True) or not (False).  This feature is currently in experimental 
-      stages but we intend to flip the default value to True at some point.  
+      is enabled (True) or not (False).   
         
   EG_KERNEL_LOG_DIR=/tmp 
       The directory used during remote kernel launches of DistributedProcessProxy

--- a/docs/source/getting-started-security.md
+++ b/docs/source/getting-started-security.md
@@ -1,0 +1,104 @@
+## Security Features
+Jupyter Enterprise Gateway does not currently perform user _authentication_ but, instead, assumes that all users
+issuing requests have been previously authenticated.  Recommended applications for this are 
+[Apache Knox](https://knox.apache.org/) or perhaps even [Jupyter Hub](https://jupyterhub.readthedocs.io/en/latest/) 
+(e.g., if nb2kg-enabled notebook servers were spawned targeting an Enterprise Gateway cluster).
+
+This section introduces some of the security features inherent in Enterprise Gateway (with more to come).
+
+**KERNEL_USERNAME**
+
+In order to convey the name of the authenicated user, `KERNEL_USERNAME` should be sent in the kernel creation request 
+via the `env:` entry.  This will occur automatically within NB2KG since it propagates all environment variables 
+prefixed with `KERNEL_`.  If the request does not include a `KERNEL_USERNAME` entry, one will be added to the kernel's
+launch environment with the value of the gateway user.
+
+This value is then used within the _authorization_ and _impersonation_ functionality.
+
+### Authorization
+By default, all users are authorized to start kernels.  This behavior can be adjusted when situations arise where
+more control is required.  Basic authorization can be expressed in two ways.
+
+##### Authorized Users
+The command-line or configuration file option: `EnterpriseGatewayApp.authorized_users` can be specified to contain a
+list of user names indicating which users are permitted to launch kernels within the current gateway server.  
+
+On each kernel launched, the authorized users list is searched for the value of `KERNEL_USERNAME` (case-sensitive).  If 
+the user is found in the list the kernel's launch sequence continues, otherwise HTTP Error 403 (Forbidden) is raised
+and the request fails.
+
+**Warning:** Since the `authorized_users` option must be exhaustive, it should be used only in situations where a small 
+and limited set of users are allowed access and empty otherwise.
+ 
+##### Unauthorized Users
+The command-line or configuration file option: `EnterpriseGatewayApp.unauthorized_users` can be specified to contain a
+list of user names indicating which users are **NOT** permitted to launch kernels within the current gateway server. 
+The `unauthorized_users` list is always checked prior to the `authorized_users` list.  If the value of `KERNEL_USERNAME`
+appears in the `unauthorized_users` list, the request is immediately failed with the same 403 (Forbidden) HTTP Error.
+
+From a system security standpoint, privileged users (e.g., `root` and any users allowed `sudo` privileges) should be
+added to this option.
+
+##### Authorization Failures
+
+It should be noted that the corresponding messages logged when each of the above authorization failures occur are 
+slightly different.  This allows the administrator to discern from which authorization list the failure was generated.  
+
+Failures stemming from _inclusion_ in the `unauthorized_users` list will include text similar to the following:
+
+`User 'bob' is not authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure 
+KERNEL_USERNAME is set to an appropriate value and retry the request.`
+
+Failures stemming from _exclusion_ from a non-empty `authorized_users` list will include text similar to the following:
+
+`User 'bob' is not in the set of users authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure 
+KERNEL_USERNAME is set to an appropriate value and retry the request.`
+
+### User Impersonation
+
+User impersonation is not performed with the Enterprise Gateway server, but is instead performed within the kernelspec
+framework.  With respect to the Enterprise Gateway sample kernels, impersonation is triggered from within the `run.sh`
+scripts.  However, the Enterprise Gateway server is what communicates the intention to perform user via two pieces of
+information: `EG_IMPERSONATION_ENABLED` and `KERNEL_USERNAME`.
+
+`EG_IMPERSONATION_ENABLED` indicates the intention that user impersonation should be performed and is conveyed via
+the command-line boolean option `EnterpriseGatewayApp.impersonation_enabled` (default = False).  This value is then
+set into the environment used to launch the kernel, where `run.sh` then acts on it - performing the appropriate logic
+to trigger user impersonation when True.  As a result, it is important that the contents of kernelspecs also be secure and trusted.
+
+`KERNEL_USERNAME` is also conveyed within the environment of the kernel launch sequence where 
+its value is used to indicate the user that should be impersonated.
+
+##### Impersonation in YARN Cluster Mode
+The recommended approach for performing user impersonation when the kernel is launched using the YARN resource manager
+is to configure the `spark-submit` command within 
+[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh) to use the `--proxy-user ${KERNEL_USERNAME}` option.  This YARN option 
+requires that kerberos be configured within the cluster.  Please refer to the 
+[Hadoop documentation](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html) 
+regarding the proper configuration of `--proxy-user`.
+
+##### Impersonation in Standalone or YARN Client Mode
+Impersonation performed in standalone or YARN cluster modes tends to take the form of using `sudo` to perform the 
+kernel launch as the target user.  This can also be configured within the 
+[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_client/bin/run.sh) script and requires the following:
+
+1. The gateway user (i.e., the user in which Enterprise Gateway is running) must be enabled to perform sudo operations
+on each potential host.  This enablement must also be done to prevent password prompts since Enterprise Gateway runs
+in the background.  Refer to your operating system documentation for details.
+2. Each user identified by `KERNEL_USERNAME` must be associated with an actual operating system user on each host.
+3. Once the gateway user is configured for `sudo` privileges it is **strongly recommended** that that user be included
+in the set of `unauthorized_users`.  Otherwise, kernels not configured for impersonation, or those requests that do not
+include `KERNEL_USERNAME`, will run as the, now, highly privileged gateway user!  
+
+WARNING: Should impersonation be disabled after granting the gateway user elevated privileges, it is 
+**strongly recommended** those privileges be revoked (on all hosts) prior to starting kernels since those kernels
+will run as the gateway user **regardless of the value of KERNEL_USERNAME**.
+
+### SSH Tunneling
+
+Jupyter Enterprise Gateway is now configured to perform SSH tunneling on the five ZeroMQ kernel sockets as well as the 
+communication socket created within the launcher and used to perform remote and cross-user signalling functionality.
+
+Should issues arise with respect to SSH tunneling, tunneling can be disabled via the environment variable 
+`EG_ENABLE_TUNNELING=False`.  Note, there is no command-line or configuration file support for this variable.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ the number of active kernels can be dramatically increased.
    getting-started-client-mode
    getting-started-advanced-features
    getting-started-kernels
+   getting-started-security
 
 .. toctree::
    :maxdepth: 2

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -70,6 +70,9 @@ class DistributedProcessProxy(RemoteProcessProxy):
         kid = env_dict.get('KERNEL_ID')
         if kid:
             cmd += 'export KERNEL_ID="{}";'.format(kid)
+        impersonation = env_dict.get('EG_IMPERSONATION_ENABLED')
+        if impersonation:
+            cmd += 'export EG_IMPERSONATION_ENABLED="{}";'.format(impersonation)
 
         for key, value in self.kernel_manager.kernel_spec.env.items():
             cmd += "export {}={};".format(key, json.dumps(value).replace("'", "''"))

--- a/etc/kernelspecs/spark_R_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_R_yarn_client/bin/run.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="sudo PATH=${PATH} -H -E -u ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
+echo
+echo "Starting IRkernel for Spark in Yarn Client mode ${USER_CLAUSE}"
+echo
+
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
 
-echo
-echo "Starting IRkernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
-
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
 set -x
-eval exec \
+eval exec "${IMPERSONATION_OPTS}" \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
      "${PROG_HOME}/scripts/launch_IRkernel.R" \

--- a/etc/kernelspecs/spark_R_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_R_yarn_cluster/bin/run.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="--proxy-user ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
+echo
+echo "Starting IRkernel for Spark in Yarn Cluster mode ${USER_CLAUSE}"
+echo
+
 if [ -z "${SPARK_HOME}" ]; then
   echo "SPARK_HOME must be set to the location of a Spark distribution!"
   exit 1
 fi
-
-echo
-echo "Starting IRkernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
-echo
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
@@ -15,6 +23,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
+     "${IMPERSONATION_OPTS}" \
      "${PROG_HOME}/scripts/launch_IRkernel.R" \
      "${LAUNCH_OPTS}" \
      "$@"

--- a/etc/kernelspecs/spark_python_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_python_yarn_client/bin/run.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="sudo PATH=${PATH} -H -E -u ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
 echo
-echo "Starting IPython kernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting IPython kernel for Spark in Yarn Client mode ${USER_CLAUSE}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then
@@ -12,7 +20,7 @@ fi
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 
 set -x
-eval exec \
+eval exec "${IMPERSONATION_OPTS}" \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
      "${PROG_HOME}/scripts/launch_ipykernel.py" \

--- a/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="--proxy-user ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
 echo
-echo "Starting IPython kernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting IPython kernel for Spark in Yarn Cluster mode ${USER_CLAUSE}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then
@@ -15,6 +23,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
+     "${IMPERSONATION_OPTS}" \
      "${PROG_HOME}/scripts/launch_ipykernel.py" \
      "${LAUNCH_OPTS}" \
      "$@"

--- a/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="sudo PATH=${PATH} -H -E -u ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
 echo
-echo "Starting Scala kernel for Spark in Yarn Client mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting Scala kernel for Spark in Yarn Client mode ${USER_CLAUSE}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then
@@ -30,7 +38,7 @@ LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
 LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
 
 set -x
-eval exec \
+eval exec "${IMPERSONATION_OPTS}" \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
      --jars "${JARS}" \

--- a/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
+if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
+        IMPERSONATION_OPTS="--proxy-user ${KERNEL_USERNAME:-UNSPECIFIED}"
+        USER_CLAUSE="as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+else
+        IMPERSONATION_OPTS=""
+        USER_CLAUSE="on behalf of user ${KERNEL_USERNAME:-UNSPECIFIED}"
+fi
+
 echo
-echo "Starting Scala kernel for Spark in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo "Starting Scala kernel for Spark in Yarn Cluster mode ${USER_CLAUSE}"
 echo
 
 if [ -z "${SPARK_HOME}" ]; then
@@ -33,6 +41,7 @@ set -x
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
      "${SPARK_OPTS}" \
+     "${IMPERSONATION_OPTS}" \
      --jars "${JARS}" \
      --class launcher.ToreeLauncher \
      "${LAUNCHER_APP}" \


### PR DESCRIPTION
This change introduces initial support for user authorization and
impersonation via the following:

- Three command-line options have been added,
`EnterpriseGatewayApp.impersonation_enabled` (boolean, default = False),
`EnterpriseGatewayApp.authorized_users` (set, default = empty), and
`EnterpriseGatewayApp.unauthorized_users` (set, default = {root}).
- Defaults KERNEL_USERNAME to the gateway user prior to authorization if
not provided in request.
- Checks if value of KERNEL_USERNAME is in `unauthorized_users`, if so
403 error is raised, else launch steps continue.
- Checks if `authorized_users` is non-empty and if KERNEL_USERNAME is
not in set.  If not included, 403 error is raise, else launch steps
continue. If set is empty, launch continues.
- Adds both KERNEL_USERNAME and EG_IMPERSONATION_ENABLED values to kernel
launch environment.
- Updates all 6 run.sh example scripts with check for
EG_IMPERSONATION_ENABLED and perform necessary commands to trigger
user impersonation.
- Enables use of communication port to perform `is_alive()` polling since signals can't
be sent across user boundaries.
- Adds `Securtiy Features` section to online docs.

Fixes #215 and #50