### PR TITLE
Add JupyterLab option to elyra/nb2kg image.

### DIFF
--- a/etc/docker/nb2kg/Dockerfile
+++ b/etc/docker/nb2kg/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-FROM jupyter/minimal-notebook:fa77fe99579b
+FROM jupyter/minimal-notebook
 
 # pip packages
 RUN pip install --upgrade pip
@@ -10,13 +10,14 @@ RUN pip install setuptools --ignore-installed --upgrade
 # Do the pip installs as the unprivileged notebook user
 USER jovyan
 
-# Install dashboard layout and preview within Jupyter Notebook
-RUN pip install "git+https://github.com/jupyter/kernel_gateway_demos.git#egg=nb2kg&subdirectory=nb2kg" && \
+# Install Lab and NB2KG. Enable NB2KG extension.  Lab extension is optionally enabled at runtime.
+RUN pip install jupyterlab "git+https://github.com/jupyter/kernel_gateway_demos.git#egg=nb2kg&subdirectory=nb2kg" && \
     jupyter serverextension enable --py nb2kg --sys-prefix
 
 ADD start-nb2kg.sh /usr/local/share/jupyter/
 
 # Run with remote kernel managers
-CMD ["/usr/local/share/jupyter/start-nb2kg.sh"]
+ENTRYPOINT ["/usr/local/share/jupyter/start-nb2kg.sh"]
+CMD ["notebook"]
 
 WORKDIR /home/jovyan/work

--- a/etc/docker/nb2kg/README.md
+++ b/etc/docker/nb2kg/README.md
@@ -1,9 +1,17 @@
-This image adds the current master branch commit from [jupyter/kernel_gateway_demos/nb2kg](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) on top of image [jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook) with tag [`fa77fe99579b`](https://github.com/jupyter/docker-stacks/commit/fa77fe99579b7bf79f6c6311e933c5118e0ec897).  It must continue to use that image tag until NB2KG's dependencies are expanded to include Notebook versions >= 5.0.0.
-
-The tag of the elyra/nb2kg image corresponds to the commit hash within the [juptyer/kernel_gateway_demos](https://github.com/jupyter/kernel_gateway_demos) repo.
+This image installs the Jupyter server extensions [NB2KG](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) 
+and [Jupyter Lab](https://github.com/jupyterlab/jupyterlab) 
+ on top of image [jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook).
 
 # What it Gives You
-This image is configured to be run against [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) instances, although running against Jupyter Kernel Gateway instances should be fine.
+This image is configured to be run against [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) 
+instances, although running against Jupyter Kernel Gateway instances should be fine.  It enables the ability to target
+either form of gateway using either `Jupyter Notebook` or `Jupyter Lab`.
+
+It is built using the latest `minimal-notebook` image and includes the `Jupyter Lab` extension that can be optionally 
+invoked.  The hashed-valued tag of the image corresponds to the `NB2KG` commit hash within the 
+[juptyer/kernel_gateway_demos/nb2kg](https://github.com/jupyter/kernel_gateway_demos/nb2kg) repo that is included 
+in the image.
+
 
 # Basic Use
 If the gateway server is remote, the following command can be used to direct NB2KG to that gateway...
@@ -24,3 +32,18 @@ You can then run multiple notebook sessions on the same host by using different 
 `docker run -t --rm -p 9003:8888 -e GATEWAY_HOST=<gateway-hostname> -e KG_HTTP_USER=bob -v <host-notebook-directory>:/home/jovyan/work elyra/nb2kg`
 
 Here, the notebook will be available at port `9003` on the host and the `KERNEL_USERNAME` variable will be set to `bob`. Note that in this case, `-e NB_PORT` is not used since the gateway is not on the same host (in this example).
+
+### Jupyter Lab 
+The jupyter lab extension can be utilized by adding `lab` as the last argument to the `docker run` command.
+
+`docker run -t --rm -p 8888:8888 -e GATEWAY_HOST=<gateway-hostname> -v <host-notebook-directory>:/home/jovyan/work elyra/nb2kg:<tag> lab`
+
+To confirm the container is running as Jupyter Lab, the log output should be prefixed with a timestamp containing 
+`LabApp` vs. `NotebookApp` for the default case.
+```
+[I 16:04:55.467 LabApp] The Jupyter Notebook is running at: http://0.0.0.0:8888/?token=209f7c7dfdfd9ebe9635ed5577a3df204b625a4040225b51
+[I 16:04:55.468 LabApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
+```
+
+**Note:** the container can be launched into the bash shell by providing a command entry that is neither `lab` nor 
+`notebook` (the default).

--- a/etc/docker/nb2kg/start-nb2kg.sh
+++ b/etc/docker/nb2kg/start-nb2kg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export NB_PORT=${NB_PORT:-8888}
 export GATEWAY_HOST=${GATEWAY_HOST:-localhost}
@@ -11,7 +11,20 @@ echo "Starting nb2kg against gateway: " ${KG_URL}
 echo "Nootbook port: " ${NB_PORT}
 echo "Kernel user: " ${KERNEL_USERNAME}
 
-jupyter notebook \
+CMD=${1:-"notebook"}
+if [[ "${CMD}" == "lab" ]];
+then
+	jupyter serverextension enable --py jupyterlab --sys-prefix
+elif [[ "${CMD}" != "notebook" ]];
+then
+	echo ""
+	echo "usage: <docker run arguments> [notebook | lab]"
+	echo "Entering shell..."
+	/bin/bash
+	exit 0
+fi
+
+jupyter ${CMD} \
   --NotebookApp.session_manager_class=nb2kg.managers.SessionManager \
   --NotebookApp.kernel_manager_class=nb2kg.managers.RemoteKernelManager \
   --NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager \


### PR DESCRIPTION
Now that nb2kg can run with notebooks > 5.0, we can extend the docker
image to include the JupyterLab extension.  This pull request does the
following:

- Removes the requirement that a particular docker image (corresponding
to a pre-5.0 Notebook version) be used.  Now the latest minimal-notebook
image is used.
- Installs the Jupyter Lab server extension.
- Updates the entrypoint to recognize a `lab` command.  If the container
is started with `lab` as the `CMD`, it enables the jupyter lab server
extension and invokes `jupyter lab` with the `NB2KG` extension.
- Defaults the `CMD` to `notebook` such that no command or a command of
`notebook` launches `jupyter notebook` with the `NB2KG` extension.
- Any `CMD` values that are not `lab` or `notebook` will invoke the bash
shell into the container (for troubleshooting).
- Updates the README accordingly.

Fixes #236