### PR TITLE
Add proxy configuration to kernelspec

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -293,3 +293,26 @@ The following environment variables may be useful for troubleshooting:
 
 ```
 
+### Per-kernel Configuration Overrides
+As mentioned in the overview of [Process Proxy Configuration](system-architecture.html#process-proxy-configuration)
+capabilities, it's possible to override or amend specific system-level configuration values on a per-kernel basis. 
+The following enumerates the set of per-kernel configuration overrides:
+
+* `remote_hosts`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.remote_hosts`. 
+Any values specified in the config dictionary override the globally defined values.  These apply to all 
+`DistributedProcessProxy` kernels.
+* `yarn_endpoint`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.yarn_endpoint`. 
+Any values specified in the config dictionary override the globally defined values.  These apply to all 
+`YarnClusterProcessProxy` kernels.  Note that you'll likely be required to specify a different `HADOOP_CONF_DIR` 
+setting in the kernel.json's `env` stanza in order of the `spark-submit` command to target the appropriate YARN cluster.
+* `authorized_users`: This process proxy configuration entry can be used to override 
+`--EnterpriseGatewayApp.authorized_users`.  Any values specified in the config dictionary override the globally 
+defined values.  These values apply to **all** process-proxy kernels, including the default `LocalProcessProxy`.  Note 
+that the typical use-case for this value is to not set `--EnterpriseGatewayApp.authorized_users` at the global level, 
+but then restrict access at the kernel level.
+* `unauthorized_users`: This process proxy configuration entry can be used to **_amend_** 
+`--EnterpriseGatewayApp.unauthorized_users`.  Any values specified in the config dictionary are **added** to the 
+globally defined values.  As a result, once a user is denied access at the global level, they will _always be denied 
+access at the kernel level_.  These values apply to **all** process-proxy kernels, including the default 
+`LocalProcessProxy`.  
+

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -95,7 +95,7 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
             self.log.debug("Instantiating kernel '{}' with process proxy: {}".
                            format(self.kernel_spec.display_name, self.kernel_spec.process_proxy_class))
             process_proxy_class = import_item(self.kernel_spec.process_proxy_class)
-            self.process_proxy = process_proxy_class(kernel_manager=self)
+            self.process_proxy = process_proxy_class(kernel_manager=self, proxy_config=self.kernel_spec.process_proxy_config)
 
         return super(RemoteKernelManager, self).start_kernel(**kw)
 

--- a/enterprise_gateway/services/kernelspecs/remotekernelspec.py
+++ b/enterprise_gateway/services/kernelspecs/remotekernelspec.py
@@ -19,11 +19,14 @@ class RemoteKernelSpec(KernelSpec):
         super(RemoteKernelSpec, self).__init__(resource_dir, **kernel_dict)
         # defaults...
         self.process_proxy_class = 'enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy'
+        self.process_proxy_config = {}
 
         if 'process_proxy' in kernel_dict and kernel_dict['process_proxy']:
-            self.process_proxy_class = kernel_dict['process_proxy']['class_name']
+            self.process_proxy_class = kernel_dict['process_proxy'].get('class_name', self.process_proxy_class)
+            self.process_proxy_config = kernel_dict['process_proxy'].get('config', self.process_proxy_config)
 
     def to_dict(self):
         d = super(RemoteKernelSpec, self).to_dict()
-        d.update({'process_proxy': {'class_name': self.process_proxy_class}})
+        d.update({'process_proxy': {'class_name': self.process_proxy_class,
+                                    'config': self.process_proxy_config}})
         return d

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -17,9 +17,12 @@ kernel_log_dir = os.getenv("EG_KERNEL_LOG_DIR", '/tmp')  # would prefer /var/log
 class DistributedProcessProxy(RemoteProcessProxy):
     host_index = 0
 
-    def __init__(self, kernel_manager):
-        super(DistributedProcessProxy, self).__init__(kernel_manager)
-        self.hosts = kernel_manager.parent.parent.remote_hosts  # from command line or env
+    def __init__(self, kernel_manager, proxy_config):
+        super(DistributedProcessProxy, self).__init__(kernel_manager, proxy_config)
+        if proxy_config.get('remote_hosts'):
+            self.hosts = proxy_config.get('remote_hosts').split(',')
+        else:
+            self.hosts = kernel_manager.parent.parent.remote_hosts  # from command line or env
 
     def launch_process(self, kernel_cmd, **kw):
         super(DistributedProcessProxy, self).launch_process(kernel_cmd, **kw)

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -32,10 +32,10 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
     initial_states = {'NEW', 'SUBMITTED', 'ACCEPTED', 'RUNNING'}
     final_states = {'FINISHED', 'KILLED'}  # Don't include FAILED state
 
-    def __init__(self, kernel_manager):
-        super(YarnClusterProcessProxy, self).__init__(kernel_manager)
+    def __init__(self, kernel_manager, proxy_config):
+        super(YarnClusterProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.application_id = None
-        self.yarn_endpoint = kernel_manager.parent.parent.yarn_endpoint  # from command line or env
+        self.yarn_endpoint = proxy_config.get('yarn_endpoint', kernel_manager.parent.parent.yarn_endpoint)
         yarn_master = urlparse(self.yarn_endpoint).hostname
         self.resource_mgr = ResourceManager(address=yarn_master)
 


### PR DESCRIPTION
With this PR, administrators have the ability to set configuration values
relative to specific kernels via the `process_proxy` stanza. In addition,
some configuration values can be used to override system-level values, thereby
allowing administrators to better control/segment system resources or user
authorizations.

The proxy configuration dictionary is read during the load of the kernelspec
and conveyed to each process-proxy constructor in the given class hierarchy.
Which classes utilize the information is a function of that particular class'
purpose.

See online docs for details and examples.

Fixes #161