### PR TITLE
[Issue #239] Connection info not returned from launchers in Python 3

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -523,7 +523,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
                         ready_to_connect = True
                         self._update_connection(connect_info)
                         break
-                    data = data + buffer  # append what we received until we get no more...
+                    data = data + buffer.decode(encoding='utf-8')  # append what we received until we get no more...
             except Exception as e:
                 if type(e) is timeout:
                     self.log.debug("Waiting for KernelID '{}' to send connection info from host '{}' - retrying..."


### PR DESCRIPTION
Although the launcher is encoding the payload containing the connection information,
the Enterprise Gateway server was not decoding the response.  Although this is
tolerated in Python 2 envs, it isn't tolerated in Python 3.  This fixes that issue
by decoding the payload for `utf-8`.

Fixes #239