### PR TITLE
Integration test enhancement

### DIFF
--- a/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
@@ -1,141 +1,68 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### If no print, will be execute_result otherwise stream"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "application_1502395407456_0041\n"
+      "Hello World\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "u'1534387b-0664-4bf8-819a-1b41827871ba'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# DIFFERENT\n",
-    "print sc.applicationId\n",
-    "sc.appName"
+    "print(\"Hello World\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Import lib, define function/class, declare variables, will not return any message/output"
+    "### Now create a SparkContext"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import numpy, os, sys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def test():\n",
-    "    print \"this is a test\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "class Demo(object):\n",
-    "    def __init__(self):\n",
-    "        self.val = 10"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "a = 10"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Multi-output-type"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "this is a test\n",
-      "this is a test\n",
-      "this is a test\n"
+      "application_1512070656800_0215\n"
      ]
     }
    ],
    "source": [
-    "test()\n",
-    "test()\n",
-    "test()"
+    "# DIFFERENT\n",
+    "print sc.applicationId"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "u'2.1.1.2.6.1.0-129'"
+       "u'2.1.1.2.6.2.0-205'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -143,6 +70,72 @@
    "source": [
     "# DEPENDS\n",
     "sc.version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'yarn'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.getConf().get(\"spark.master\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'client'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.getConf().get(\"spark.submit.deployMode\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.16.156.107\n"
+     ]
+    }
+   ],
+   "source": [
+    "# DEPENDS\n",
+    "print sc.getConf().get(\"spark.driver.host\")"
    ]
   }
  ],
@@ -155,14 +148,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.5"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Cluster1.ipynb
@@ -1,141 +1,68 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### If no print, will be execute_result otherwise stream"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "application_1500314514041_0209\n"
+      "Hello World\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "u'3aabd00c-1443-4918-b5fa-521f20edfd88'"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "# DIFFERENT\n",
-    "print sc.applicationId\n",
-    "sc.appName"
+    "print(\"Hello World\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Import lib, define function/class, declare variables, will not return any message/output"
+    "### Now create a SparkContext"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "import numpy, os, sys"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "def test():\n",
-    "    print \"this is a test\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "class Demo(object):\n",
-    "    def __init__(self):\n",
-    "        self.val = 10"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "a = 10"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Multi-output-type"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "this is a test\n",
-      "this is a test\n",
-      "this is a test\n"
+      "application_1512070656800_0216\n"
      ]
     }
    ],
    "source": [
-    "test()\n",
-    "test()\n",
-    "test()"
+    "# DIFFERENT\n",
+    "print sc.applicationId"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "u'2.1.1.2.6.1.0-129'"
+       "u'2.1.1.2.6.2.0-205'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -143,6 +70,72 @@
    "source": [
     "# DEPENDS\n",
     "sc.version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'yarn'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.getConf().get(\"spark.master\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "u'cluster'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sc.getConf().get(\"spark.submit.deployMode\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.16.155.186\n"
+     ]
+    }
+   ],
+   "source": [
+    "# DEPENDS\n",
+    "print sc.getConf().get(\"spark.driver.host\")"
    ]
   }
  ],
@@ -155,14 +148,14 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.5"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/enterprise_gateway/itests/notebooks/R_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Client1.ipynb
@@ -1,121 +1,22 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Use Spark for R to load data and run SQL queries\n",
-    "This notebook introduces basic Spark concepts and helps you to start using Spark for R.\n",
-    "\n",
-    "Some familiarity with R is recommended. This notebook runs on R with Spark 2.0.\n",
-    "\n",
-    "In this notebook, you'll use the publicly available **mtcars** data set from *Motor Trend* magazine to learn some basic R. You'll learn how to load data, create a Spark DataFrame, aggregate data, run mathematical formulas, and run SQL queries against the data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Table of contents\n",
-    "This notebook contains these main sections:\n",
-    "\n",
-    "1. [Load a DataFrame](#Load_a_DataFrame)\n",
-    "2. [Initialize an SQLContext](#Initialize_an_SQLContext)\n",
-    "3. [Create a Spark DataFrame](#Create_a_Spark_DataFrame)\n",
-    "4. [Aggregate data after grouping by columns](#Aggregate_data_after_grouping_by_columns)\n",
-    "5. [Operate on columns](#Operate_on_columns)\n",
-    "6. [Run SQL queries from the Spark DataFrame](#Run_SQL_queries_from_the_Spark_DataFrame)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Load_a_DataFrame'></a>\n",
-    "## 1. Load a DataFrame\n",
-    "A DataFrame is a distributed collection of data that is organized into named columns. The built-in R DataFrame called **mtcars** includes observations on the following 11 variables:\n",
-    "\n",
-    "`[, 1]\tmpg     Miles / (US) gallon`  \n",
-    "`[, 2]\tcyl     Number of cylinders`  \n",
-    "`[, 3]\tdisp\tDisplacement (cu. in.)`  \n",
-    "`[, 4]\thp      Gross horsepower`  \n",
-    "`[, 5]\tdrat    Rear axle ratio`  \n",
-    "`[, 6]\twt      Weight (1000 lbs)`  \n",
-    "`[, 7]\tqsec    1/4 mile time (seconds)`  \n",
-    "`[, 8]\tvs      0 = V-engine, 1 = straight engine`  \n",
-    "`[, 9]\tam      Transmission (0 = automatic, 1 = manual)`  \n",
-    "`[,10]\tgear    Number of forward gears`  \n",
-    "`[,11]\tcarb    Number of carburetors`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Preview the first 3 rows of the DataFrame by using the head() function:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
+    "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th></th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><th scope=row>Mazda RX4</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.620</td><td>16.46</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
-       "\t<tr><th scope=row>Mazda RX4 Wag</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.875</td><td>17.02</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
-       "\t<tr><th scope=row>Datsun 710</th><td>22.8 </td><td>4    </td><td>108  </td><td> 93  </td><td>3.85 </td><td>2.320</td><td>18.61</td><td>1    </td><td>1    </td><td>4    </td><td>1    </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|lllllllllll}\n",
-       "  & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
-       "\\hline\n",
-       "\tMazda RX4 & 21.0  & 6     & 160   & 110   & 3.90  & 2.620 & 16.46 & 0     & 1     & 4     & 4    \\\\\n",
-       "\tMazda RX4 Wag & 21.0  & 6     & 160   & 110   & 3.90  & 2.875 & 17.02 & 0     & 1     & 4     & 4    \\\\\n",
-       "\tDatsun 710 & 22.8  & 4     & 108   &  93   & 3.85  & 2.320 & 18.61 & 1     & 1     & 4     & 1    \\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "| <!--/--> | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
-       "|---|---|---|\n",
-       "| Mazda RX4 | 21.0  | 6     | 160   | 110   | 3.90  | 2.620 | 16.46 | 0     | 1     | 4     | 4     | \n",
-       "| Mazda RX4 Wag | 21.0  | 6     | 160   | 110   | 3.90  | 2.875 | 17.02 | 0     | 1     | 4     | 4     | \n",
-       "| Datsun 710 | 22.8  | 4     | 108   |  93   | 3.85  | 2.320 | 18.61 | 1     | 1     | 4     | 1     | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "              mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
-       "Mazda RX4     21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
-       "Mazda RX4 Wag 21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
-       "Datsun 710    22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1] \"Hello World\"\n"
+     ]
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "# Since this display_data would be transformed into mark down of <table></table>\n",
-    "head(mtcars, 3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Convert the car name data, which appears in the row names, into an actual column so that Spark can read it as a column:"
+    "print(\"Hello World\")"
    ]
   },
   {
@@ -126,53 +27,26 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Obtaining Spark session...\n",
+      "Spark session obtained.\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4        </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.620            </td><td>16.46            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag    </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.875            </td><td>17.02            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
-       "\t<tr><td>Datsun 710       </td><td>22.8             </td><td>4                </td><td>108              </td><td> 93              </td><td>3.85             </td><td>2.320            </td><td>18.61            </td><td>1                </td><td>1                </td><td>4                </td><td>1                </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive   </td><td>21.4             </td><td>6                </td><td>258              </td><td>110              </td><td>3.08             </td><td>3.215            </td><td>19.44            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout</td><td>18.7             </td><td>8                </td><td>360              </td><td>175              </td><td>3.15             </td><td>3.440            </td><td>17.02            </td><td>0                </td><td>0                </td><td>3                </td><td>2                </td></tr>\n",
-       "\t<tr><td>Valiant          </td><td>18.1             </td><td>6                </td><td>225              </td><td>105              </td><td>2.76             </td><td>3.460            </td><td>20.22            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "'application_1512070656800_0218'"
       ],
       "text/latex": [
-       "\\begin{tabular}{r|llllllllllll}\n",
-       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
-       "\\hline\n",
-       "\t Mazda RX4         & 21.0              & 6                 & 160               & 110               & 3.90              & 2.620             & 16.46             & 0                 & 1                 & 4                 & 4                \\\\\n",
-       "\t Mazda RX4 Wag     & 21.0              & 6                 & 160               & 110               & 3.90              & 2.875             & 17.02             & 0                 & 1                 & 4                 & 4                \\\\\n",
-       "\t Datsun 710        & 22.8              & 4                 & 108               &  93               & 3.85              & 2.320             & 18.61             & 1                 & 1                 & 4                 & 1                \\\\\n",
-       "\t Hornet 4 Drive    & 21.4              & 6                 & 258               & 110               & 3.08              & 3.215             & 19.44             & 1                 & 0                 & 3                 & 1                \\\\\n",
-       "\t Hornet Sportabout & 18.7              & 8                 & 360               & 175               & 3.15              & 3.440             & 17.02             & 0                 & 0                 & 3                 & 2                \\\\\n",
-       "\t Valiant           & 18.1              & 6                 & 225               & 105               & 2.76              & 3.460             & 20.22             & 1                 & 0                 & 3                 & 1                \\\\\n",
-       "\\end{tabular}\n"
+       "'application\\_1512070656800\\_0218'"
       ],
       "text/markdown": [
-       "\n",
-       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
-       "|---|---|---|---|---|---|\n",
-       "| Mazda RX4         | 21.0              | 6                 | 160               | 110               | 3.90              | 2.620             | 16.46             | 0                 | 1                 | 4                 | 4                 | \n",
-       "| Mazda RX4 Wag     | 21.0              | 6                 | 160               | 110               | 3.90              | 2.875             | 17.02             | 0                 | 1                 | 4                 | 4                 | \n",
-       "| Datsun 710        | 22.8              | 4                 | 108               |  93               | 3.85              | 2.320             | 18.61             | 1                 | 1                 | 4                 | 1                 | \n",
-       "| Hornet 4 Drive    | 21.4              | 6                 | 258               | 110               | 3.08              | 3.215             | 19.44             | 1                 | 0                 | 3                 | 1                 | \n",
-       "| Hornet Sportabout | 18.7              | 8                 | 360               | 175               | 3.15              | 3.440             | 17.02             | 0                 | 0                 | 3                 | 2                 | \n",
-       "| Valiant           | 18.1              | 6                 | 225               | 105               | 2.76              | 3.460             | 20.22             | 1                 | 0                 | 3                 | 1                 | \n",
-       "\n",
-       "\n"
+       "'application_1512070656800_0218'"
       ],
       "text/plain": [
-       "  car               mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
-       "1 Mazda RX4         21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
-       "2 Mazda RX4 Wag     21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
-       "3 Datsun 710        22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   \n",
-       "4 Hornet 4 Drive    21.4 6   258  110 3.08 3.215 19.44 1  0  3    1   \n",
-       "5 Hornet Sportabout 18.7 8   360  175 3.15 3.440 17.02 0  0  3    2   \n",
-       "6 Valiant           18.1 6   225  105 2.76 3.460 20.22 1  0  3    1   "
+       "[1] \"application_1512070656800_0218\""
       ]
      },
      "metadata": {},
@@ -180,20 +54,8 @@
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "mtcars$car <- rownames(mtcars)\n",
-    "mtcars <- mtcars[,c(12,1:11)]\n",
-    "rownames(mtcars) <- 1:nrow(mtcars)\n",
-    "head(mtcars)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Initialize_an_SQLContext'></a>\n",
-    "## 2. Initialize an SQLContext\n",
-    "To work with a DataFrame, you need an SQLContext. You create this SQLContext by using `sparkRSQL.init(sc)`. A SparkContext named sc, which has been created for you, is used to initialize the SQLContext:"
+    "#DIFFERENT\n",
+    "SparkR:::callJMethod(SparkR:::callJMethod(sc, \"sc\"), \"applicationId\")"
    ]
   },
   {
@@ -202,18 +64,29 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/latex": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/markdown": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/plain": [
+       "[1] \"2.1.1.2.6.2.0-205\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "sqlContext <- sparkR.session(sc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Create_a_Spark_DataFrame'></a>\n",
-    "## 3. Create a Spark DataFrame\n",
-    "Using the SQLContext and the loaded local DataFrame, create a Spark DataFrame and print the schema, or structure, of the DataFrame:"
+    "#DEPENDS\n",
+    "SparkR:::callJMethod(SparkR:::callJMethod(sc, \"sc\"), \"version\")"
    ]
   },
   {
@@ -224,197 +97,51 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- car: string (nullable = true)\n",
-      " |-- mpg: double (nullable = true)\n",
-      " |-- cyl: double (nullable = true)\n",
-      " |-- disp: double (nullable = true)\n",
-      " |-- hp: double (nullable = true)\n",
-      " |-- drat: double (nullable = true)\n",
-      " |-- wt: double (nullable = true)\n",
-      " |-- qsec: double (nullable = true)\n",
-      " |-- vs: double (nullable = true)\n",
-      " |-- am: double (nullable = true)\n",
-      " |-- gear: double (nullable = true)\n",
-      " |-- carb: double (nullable = true)\n"
-     ]
+     "data": {
+      "text/html": [
+       "<strong>spark.master:</strong> 'yarn'"
+      ],
+      "text/latex": [
+       "\\textbf{spark.master:} 'yarn'"
+      ],
+      "text/markdown": [
+       "**spark.master:** 'yarn'"
+      ],
+      "text/plain": [
+       "spark.master \n",
+       "      \"yarn\" "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "sdf <- createDataFrame(mtcars, schema = NULL) \n",
-    "printSchema(sdf)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display the content of the Spark DataFrame:"
+    "masterValue <- unlist(sparkR.conf(\"spark.master\"))\n",
+    "masterValue"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
-    "scrolled": false
+    "collapsed": false
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4          </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.620              </td><td>16.46              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag      </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.875              </td><td>17.02              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Datsun 710         </td><td>22.8               </td><td>4                  </td><td>108.0              </td><td> 93                </td><td>3.85               </td><td>2.320              </td><td>18.61              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive     </td><td>21.4               </td><td>6                  </td><td>258.0              </td><td>110                </td><td>3.08               </td><td>3.215              </td><td>19.44              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout  </td><td>18.7               </td><td>8                  </td><td>360.0              </td><td>175                </td><td>3.15               </td><td>3.440              </td><td>17.02              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Valiant            </td><td>18.1               </td><td>6                  </td><td>225.0              </td><td>105                </td><td>2.76               </td><td>3.460              </td><td>20.22              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Duster 360         </td><td>14.3               </td><td>8                  </td><td>360.0              </td><td>245                </td><td>3.21               </td><td>3.570              </td><td>15.84              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 240D          </td><td>24.4               </td><td>4                  </td><td>146.7              </td><td> 62                </td><td>3.69               </td><td>3.190              </td><td>20.00              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Merc 230           </td><td>22.8               </td><td>4                  </td><td>140.8              </td><td> 95                </td><td>3.92               </td><td>3.150              </td><td>22.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Merc 280           </td><td>19.2               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.30              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 280C          </td><td>17.8               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 450SE         </td><td>16.4               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>4.070              </td><td>17.40              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Merc 450SL         </td><td>17.3               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.730              </td><td>17.60              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Merc 450SLC        </td><td>15.2               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.780              </td><td>18.00              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Cadillac Fleetwood </td><td>10.4               </td><td>8                  </td><td>472.0              </td><td>205                </td><td>2.93               </td><td>5.250              </td><td>17.98              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Lincoln Continental</td><td>10.4               </td><td>8                  </td><td>460.0              </td><td>215                </td><td>3.00               </td><td>5.424              </td><td>17.82              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Chrysler Imperial  </td><td>14.7               </td><td>8                  </td><td>440.0              </td><td>230                </td><td>3.23               </td><td>5.345              </td><td>17.42              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Fiat 128           </td><td>32.4               </td><td>4                  </td><td> 78.7              </td><td> 66                </td><td>4.08               </td><td>2.200              </td><td>19.47              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Honda Civic        </td><td>30.4               </td><td>4                  </td><td> 75.7              </td><td> 52                </td><td>4.93               </td><td>1.615              </td><td>18.52              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Toyota Corolla     </td><td>33.9               </td><td>4                  </td><td> 71.1              </td><td> 65                </td><td>4.22               </td><td>1.835              </td><td>19.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Toyota Corona      </td><td>21.5               </td><td>4                  </td><td>120.1              </td><td> 97                </td><td>3.70               </td><td>2.465              </td><td>20.01              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Dodge Challenger   </td><td>15.5               </td><td>8                  </td><td>318.0              </td><td>150                </td><td>2.76               </td><td>3.520              </td><td>16.87              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>AMC Javelin        </td><td>15.2               </td><td>8                  </td><td>304.0              </td><td>150                </td><td>3.15               </td><td>3.435              </td><td>17.30              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Camaro Z28         </td><td>13.3               </td><td>8                  </td><td>350.0              </td><td>245                </td><td>3.73               </td><td>3.840              </td><td>15.41              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Pontiac Firebird   </td><td>19.2               </td><td>8                  </td><td>400.0              </td><td>175                </td><td>3.08               </td><td>3.845              </td><td>17.05              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Fiat X1-9          </td><td>27.3               </td><td>4                  </td><td> 79.0              </td><td> 66                </td><td>4.08               </td><td>1.935              </td><td>18.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Porsche 914-2      </td><td>26.0               </td><td>4                  </td><td>120.3              </td><td> 91                </td><td>4.43               </td><td>2.140              </td><td>16.70              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Lotus Europa       </td><td>30.4               </td><td>4                  </td><td> 95.1              </td><td>113                </td><td>3.77               </td><td>1.513              </td><td>16.90              </td><td>1                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Ford Pantera L     </td><td>15.8               </td><td>8                  </td><td>351.0              </td><td>264                </td><td>4.22               </td><td>3.170              </td><td>14.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Ferrari Dino       </td><td>19.7               </td><td>6                  </td><td>145.0              </td><td>175                </td><td>3.62               </td><td>2.770              </td><td>15.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>6                  </td></tr>\n",
-       "\t<tr><td>Maserati Bora      </td><td>15.0               </td><td>8                  </td><td>301.0              </td><td>335                </td><td>3.54               </td><td>3.570              </td><td>14.60              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>8                  </td></tr>\n",
-       "\t<tr><td>Volvo 142E         </td><td>21.4               </td><td>4                  </td><td>121.0              </td><td>109                </td><td>4.11               </td><td>2.780              </td><td>18.60              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "<strong>spark.submit.deployMode:</strong> 'client'"
       ],
       "text/latex": [
-       "\\begin{tabular}{r|llllllllllll}\n",
-       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
-       "\\hline\n",
-       "\t Mazda RX4           & 21.0                & 6                   & 160.0               & 110                 & 3.90                & 2.620               & 16.46               & 0                   & 1                   & 4                   & 4                  \\\\\n",
-       "\t Mazda RX4 Wag       & 21.0                & 6                   & 160.0               & 110                 & 3.90                & 2.875               & 17.02               & 0                   & 1                   & 4                   & 4                  \\\\\n",
-       "\t Datsun 710          & 22.8                & 4                   & 108.0               &  93                 & 3.85                & 2.320               & 18.61               & 1                   & 1                   & 4                   & 1                  \\\\\n",
-       "\t Hornet 4 Drive      & 21.4                & 6                   & 258.0               & 110                 & 3.08                & 3.215               & 19.44               & 1                   & 0                   & 3                   & 1                  \\\\\n",
-       "\t Hornet Sportabout   & 18.7                & 8                   & 360.0               & 175                 & 3.15                & 3.440               & 17.02               & 0                   & 0                   & 3                   & 2                  \\\\\n",
-       "\t Valiant             & 18.1                & 6                   & 225.0               & 105                 & 2.76                & 3.460               & 20.22               & 1                   & 0                   & 3                   & 1                  \\\\\n",
-       "\t Duster 360          & 14.3                & 8                   & 360.0               & 245                 & 3.21                & 3.570               & 15.84               & 0                   & 0                   & 3                   & 4                  \\\\\n",
-       "\t Merc 240D           & 24.4                & 4                   & 146.7               &  62                 & 3.69                & 3.190               & 20.00               & 1                   & 0                   & 4                   & 2                  \\\\\n",
-       "\t Merc 230            & 22.8                & 4                   & 140.8               &  95                 & 3.92                & 3.150               & 22.90               & 1                   & 0                   & 4                   & 2                  \\\\\n",
-       "\t Merc 280            & 19.2                & 6                   & 167.6               & 123                 & 3.92                & 3.440               & 18.30               & 1                   & 0                   & 4                   & 4                  \\\\\n",
-       "\t Merc 280C           & 17.8                & 6                   & 167.6               & 123                 & 3.92                & 3.440               & 18.90               & 1                   & 0                   & 4                   & 4                  \\\\\n",
-       "\t Merc 450SE          & 16.4                & 8                   & 275.8               & 180                 & 3.07                & 4.070               & 17.40               & 0                   & 0                   & 3                   & 3                  \\\\\n",
-       "\t Merc 450SL          & 17.3                & 8                   & 275.8               & 180                 & 3.07                & 3.730               & 17.60               & 0                   & 0                   & 3                   & 3                  \\\\\n",
-       "\t Merc 450SLC         & 15.2                & 8                   & 275.8               & 180                 & 3.07                & 3.780               & 18.00               & 0                   & 0                   & 3                   & 3                  \\\\\n",
-       "\t Cadillac Fleetwood  & 10.4                & 8                   & 472.0               & 205                 & 2.93                & 5.250               & 17.98               & 0                   & 0                   & 3                   & 4                  \\\\\n",
-       "\t Lincoln Continental & 10.4                & 8                   & 460.0               & 215                 & 3.00                & 5.424               & 17.82               & 0                   & 0                   & 3                   & 4                  \\\\\n",
-       "\t Chrysler Imperial   & 14.7                & 8                   & 440.0               & 230                 & 3.23                & 5.345               & 17.42               & 0                   & 0                   & 3                   & 4                  \\\\\n",
-       "\t Fiat 128            & 32.4                & 4                   &  78.7               &  66                 & 4.08                & 2.200               & 19.47               & 1                   & 1                   & 4                   & 1                  \\\\\n",
-       "\t Honda Civic         & 30.4                & 4                   &  75.7               &  52                 & 4.93                & 1.615               & 18.52               & 1                   & 1                   & 4                   & 2                  \\\\\n",
-       "\t Toyota Corolla      & 33.9                & 4                   &  71.1               &  65                 & 4.22                & 1.835               & 19.90               & 1                   & 1                   & 4                   & 1                  \\\\\n",
-       "\t Toyota Corona       & 21.5                & 4                   & 120.1               &  97                 & 3.70                & 2.465               & 20.01               & 1                   & 0                   & 3                   & 1                  \\\\\n",
-       "\t Dodge Challenger    & 15.5                & 8                   & 318.0               & 150                 & 2.76                & 3.520               & 16.87               & 0                   & 0                   & 3                   & 2                  \\\\\n",
-       "\t AMC Javelin         & 15.2                & 8                   & 304.0               & 150                 & 3.15                & 3.435               & 17.30               & 0                   & 0                   & 3                   & 2                  \\\\\n",
-       "\t Camaro Z28          & 13.3                & 8                   & 350.0               & 245                 & 3.73                & 3.840               & 15.41               & 0                   & 0                   & 3                   & 4                  \\\\\n",
-       "\t Pontiac Firebird    & 19.2                & 8                   & 400.0               & 175                 & 3.08                & 3.845               & 17.05               & 0                   & 0                   & 3                   & 2                  \\\\\n",
-       "\t Fiat X1-9           & 27.3                & 4                   &  79.0               &  66                 & 4.08                & 1.935               & 18.90               & 1                   & 1                   & 4                   & 1                  \\\\\n",
-       "\t Porsche 914-2       & 26.0                & 4                   & 120.3               &  91                 & 4.43                & 2.140               & 16.70               & 0                   & 1                   & 5                   & 2                  \\\\\n",
-       "\t Lotus Europa        & 30.4                & 4                   &  95.1               & 113                 & 3.77                & 1.513               & 16.90               & 1                   & 1                   & 5                   & 2                  \\\\\n",
-       "\t Ford Pantera L      & 15.8                & 8                   & 351.0               & 264                 & 4.22                & 3.170               & 14.50               & 0                   & 1                   & 5                   & 4                  \\\\\n",
-       "\t Ferrari Dino        & 19.7                & 6                   & 145.0               & 175                 & 3.62                & 2.770               & 15.50               & 0                   & 1                   & 5                   & 6                  \\\\\n",
-       "\t Maserati Bora       & 15.0                & 8                   & 301.0               & 335                 & 3.54                & 3.570               & 14.60               & 0                   & 1                   & 5                   & 8                  \\\\\n",
-       "\t Volvo 142E          & 21.4                & 4                   & 121.0               & 109                 & 4.11                & 2.780               & 18.60               & 1                   & 1                   & 4                   & 2                  \\\\\n",
-       "\\end{tabular}\n"
+       "\\textbf{spark.submit.deployMode:} 'client'"
       ],
       "text/markdown": [
-       "\n",
-       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
-       "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n",
-       "| Mazda RX4           | 21.0                | 6                   | 160.0               | 110                 | 3.90                | 2.620               | 16.46               | 0                   | 1                   | 4                   | 4                   | \n",
-       "| Mazda RX4 Wag       | 21.0                | 6                   | 160.0               | 110                 | 3.90                | 2.875               | 17.02               | 0                   | 1                   | 4                   | 4                   | \n",
-       "| Datsun 710          | 22.8                | 4                   | 108.0               |  93                 | 3.85                | 2.320               | 18.61               | 1                   | 1                   | 4                   | 1                   | \n",
-       "| Hornet 4 Drive      | 21.4                | 6                   | 258.0               | 110                 | 3.08                | 3.215               | 19.44               | 1                   | 0                   | 3                   | 1                   | \n",
-       "| Hornet Sportabout   | 18.7                | 8                   | 360.0               | 175                 | 3.15                | 3.440               | 17.02               | 0                   | 0                   | 3                   | 2                   | \n",
-       "| Valiant             | 18.1                | 6                   | 225.0               | 105                 | 2.76                | 3.460               | 20.22               | 1                   | 0                   | 3                   | 1                   | \n",
-       "| Duster 360          | 14.3                | 8                   | 360.0               | 245                 | 3.21                | 3.570               | 15.84               | 0                   | 0                   | 3                   | 4                   | \n",
-       "| Merc 240D           | 24.4                | 4                   | 146.7               |  62                 | 3.69                | 3.190               | 20.00               | 1                   | 0                   | 4                   | 2                   | \n",
-       "| Merc 230            | 22.8                | 4                   | 140.8               |  95                 | 3.92                | 3.150               | 22.90               | 1                   | 0                   | 4                   | 2                   | \n",
-       "| Merc 280            | 19.2                | 6                   | 167.6               | 123                 | 3.92                | 3.440               | 18.30               | 1                   | 0                   | 4                   | 4                   | \n",
-       "| Merc 280C           | 17.8                | 6                   | 167.6               | 123                 | 3.92                | 3.440               | 18.90               | 1                   | 0                   | 4                   | 4                   | \n",
-       "| Merc 450SE          | 16.4                | 8                   | 275.8               | 180                 | 3.07                | 4.070               | 17.40               | 0                   | 0                   | 3                   | 3                   | \n",
-       "| Merc 450SL          | 17.3                | 8                   | 275.8               | 180                 | 3.07                | 3.730               | 17.60               | 0                   | 0                   | 3                   | 3                   | \n",
-       "| Merc 450SLC         | 15.2                | 8                   | 275.8               | 180                 | 3.07                | 3.780               | 18.00               | 0                   | 0                   | 3                   | 3                   | \n",
-       "| Cadillac Fleetwood  | 10.4                | 8                   | 472.0               | 205                 | 2.93                | 5.250               | 17.98               | 0                   | 0                   | 3                   | 4                   | \n",
-       "| Lincoln Continental | 10.4                | 8                   | 460.0               | 215                 | 3.00                | 5.424               | 17.82               | 0                   | 0                   | 3                   | 4                   | \n",
-       "| Chrysler Imperial   | 14.7                | 8                   | 440.0               | 230                 | 3.23                | 5.345               | 17.42               | 0                   | 0                   | 3                   | 4                   | \n",
-       "| Fiat 128            | 32.4                | 4                   |  78.7               |  66                 | 4.08                | 2.200               | 19.47               | 1                   | 1                   | 4                   | 1                   | \n",
-       "| Honda Civic         | 30.4                | 4                   |  75.7               |  52                 | 4.93                | 1.615               | 18.52               | 1                   | 1                   | 4                   | 2                   | \n",
-       "| Toyota Corolla      | 33.9                | 4                   |  71.1               |  65                 | 4.22                | 1.835               | 19.90               | 1                   | 1                   | 4                   | 1                   | \n",
-       "| Toyota Corona       | 21.5                | 4                   | 120.1               |  97                 | 3.70                | 2.465               | 20.01               | 1                   | 0                   | 3                   | 1                   | \n",
-       "| Dodge Challenger    | 15.5                | 8                   | 318.0               | 150                 | 2.76                | 3.520               | 16.87               | 0                   | 0                   | 3                   | 2                   | \n",
-       "| AMC Javelin         | 15.2                | 8                   | 304.0               | 150                 | 3.15                | 3.435               | 17.30               | 0                   | 0                   | 3                   | 2                   | \n",
-       "| Camaro Z28          | 13.3                | 8                   | 350.0               | 245                 | 3.73                | 3.840               | 15.41               | 0                   | 0                   | 3                   | 4                   | \n",
-       "| Pontiac Firebird    | 19.2                | 8                   | 400.0               | 175                 | 3.08                | 3.845               | 17.05               | 0                   | 0                   | 3                   | 2                   | \n",
-       "| Fiat X1-9           | 27.3                | 4                   |  79.0               |  66                 | 4.08                | 1.935               | 18.90               | 1                   | 1                   | 4                   | 1                   | \n",
-       "| Porsche 914-2       | 26.0                | 4                   | 120.3               |  91                 | 4.43                | 2.140               | 16.70               | 0                   | 1                   | 5                   | 2                   | \n",
-       "| Lotus Europa        | 30.4                | 4                   |  95.1               | 113                 | 3.77                | 1.513               | 16.90               | 1                   | 1                   | 5                   | 2                   | \n",
-       "| Ford Pantera L      | 15.8                | 8                   | 351.0               | 264                 | 4.22                | 3.170               | 14.50               | 0                   | 1                   | 5                   | 4                   | \n",
-       "| Ferrari Dino        | 19.7                | 6                   | 145.0               | 175                 | 3.62                | 2.770               | 15.50               | 0                   | 1                   | 5                   | 6                   | \n",
-       "| Maserati Bora       | 15.0                | 8                   | 301.0               | 335                 | 3.54                | 3.570               | 14.60               | 0                   | 1                   | 5                   | 8                   | \n",
-       "| Volvo 142E          | 21.4                | 4                   | 121.0               | 109                 | 4.11                | 2.780               | 18.60               | 1                   | 1                   | 4                   | 2                   | \n",
-       "\n",
-       "\n"
+       "**spark.submit.deployMode:** 'client'"
       ],
       "text/plain": [
-       "   car                 mpg  cyl disp  hp  drat wt    qsec  vs am gear carb\n",
-       "1  Mazda RX4           21.0 6   160.0 110 3.90 2.620 16.46 0  1  4    4   \n",
-       "2  Mazda RX4 Wag       21.0 6   160.0 110 3.90 2.875 17.02 0  1  4    4   \n",
-       "3  Datsun 710          22.8 4   108.0  93 3.85 2.320 18.61 1  1  4    1   \n",
-       "4  Hornet 4 Drive      21.4 6   258.0 110 3.08 3.215 19.44 1  0  3    1   \n",
-       "5  Hornet Sportabout   18.7 8   360.0 175 3.15 3.440 17.02 0  0  3    2   \n",
-       "6  Valiant             18.1 6   225.0 105 2.76 3.460 20.22 1  0  3    1   \n",
-       "7  Duster 360          14.3 8   360.0 245 3.21 3.570 15.84 0  0  3    4   \n",
-       "8  Merc 240D           24.4 4   146.7  62 3.69 3.190 20.00 1  0  4    2   \n",
-       "9  Merc 230            22.8 4   140.8  95 3.92 3.150 22.90 1  0  4    2   \n",
-       "10 Merc 280            19.2 6   167.6 123 3.92 3.440 18.30 1  0  4    4   \n",
-       "11 Merc 280C           17.8 6   167.6 123 3.92 3.440 18.90 1  0  4    4   \n",
-       "12 Merc 450SE          16.4 8   275.8 180 3.07 4.070 17.40 0  0  3    3   \n",
-       "13 Merc 450SL          17.3 8   275.8 180 3.07 3.730 17.60 0  0  3    3   \n",
-       "14 Merc 450SLC         15.2 8   275.8 180 3.07 3.780 18.00 0  0  3    3   \n",
-       "15 Cadillac Fleetwood  10.4 8   472.0 205 2.93 5.250 17.98 0  0  3    4   \n",
-       "16 Lincoln Continental 10.4 8   460.0 215 3.00 5.424 17.82 0  0  3    4   \n",
-       "17 Chrysler Imperial   14.7 8   440.0 230 3.23 5.345 17.42 0  0  3    4   \n",
-       "18 Fiat 128            32.4 4    78.7  66 4.08 2.200 19.47 1  1  4    1   \n",
-       "19 Honda Civic         30.4 4    75.7  52 4.93 1.615 18.52 1  1  4    2   \n",
-       "20 Toyota Corolla      33.9 4    71.1  65 4.22 1.835 19.90 1  1  4    1   \n",
-       "21 Toyota Corona       21.5 4   120.1  97 3.70 2.465 20.01 1  0  3    1   \n",
-       "22 Dodge Challenger    15.5 8   318.0 150 2.76 3.520 16.87 0  0  3    2   \n",
-       "23 AMC Javelin         15.2 8   304.0 150 3.15 3.435 17.30 0  0  3    2   \n",
-       "24 Camaro Z28          13.3 8   350.0 245 3.73 3.840 15.41 0  0  3    4   \n",
-       "25 Pontiac Firebird    19.2 8   400.0 175 3.08 3.845 17.05 0  0  3    2   \n",
-       "26 Fiat X1-9           27.3 4    79.0  66 4.08 1.935 18.90 1  1  4    1   \n",
-       "27 Porsche 914-2       26.0 4   120.3  91 4.43 2.140 16.70 0  1  5    2   \n",
-       "28 Lotus Europa        30.4 4    95.1 113 3.77 1.513 16.90 1  1  5    2   \n",
-       "29 Ford Pantera L      15.8 8   351.0 264 4.22 3.170 14.50 0  1  5    4   \n",
-       "30 Ferrari Dino        19.7 6   145.0 175 3.62 2.770 15.50 0  1  5    6   \n",
-       "31 Maserati Bora       15.0 8   301.0 335 3.54 3.570 14.60 0  1  5    8   \n",
-       "32 Volvo 142E          21.4 4   121.0 109 4.11 2.780 18.60 1  1  4    2   "
+       "spark.submit.deployMode \n",
+       "               \"client\" "
       ]
      },
      "metadata": {},
@@ -422,142 +149,31 @@
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "SparkR::head(sdf, 32)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Try different ways of retrieving subsets of the data. For example, get the first 5 values in the **mpg** column:"
+    "deployMode <- unlist(sparkR.conf(\"spark.submit.deployMode\"))\n",
+    "deployMode"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>mpg</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>21.0</td></tr>\n",
-       "\t<tr><td>21.0</td></tr>\n",
-       "\t<tr><td>22.8</td></tr>\n",
-       "\t<tr><td>21.4</td></tr>\n",
-       "\t<tr><td>18.7</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|l}\n",
-       " mpg\\\\\n",
-       "\\hline\n",
-       "\t 21.0\\\\\n",
-       "\t 21.0\\\\\n",
-       "\t 22.8\\\\\n",
-       "\t 21.4\\\\\n",
-       "\t 18.7\\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "mpg | \n",
-       "|---|---|---|---|---|\n",
-       "| 21.0 | \n",
-       "| 21.0 | \n",
-       "| 22.8 | \n",
-       "| 21.4 | \n",
-       "| 18.7 | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "  mpg \n",
-       "1 21.0\n",
-       "2 21.0\n",
-       "3 22.8\n",
-       "4 21.4\n",
-       "5 18.7"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "SparkR::head(select(sdf, sdf$mpg),5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Filter the DataFrame to retain only rows with **mpg** values that are less than 18:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Duster 360        </td><td>14.3              </td><td>8                 </td><td>360.0             </td><td>245               </td><td>3.21              </td><td>3.57              </td><td>15.84             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
-       "\t<tr><td>Merc 280C         </td><td>17.8              </td><td>6                 </td><td>167.6             </td><td>123               </td><td>3.92              </td><td>3.44              </td><td>18.90             </td><td>1                 </td><td>0                 </td><td>4                 </td><td>4                 </td></tr>\n",
-       "\t<tr><td>Merc 450SE        </td><td>16.4              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>4.07              </td><td>17.40             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Merc 450SL        </td><td>17.3              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.73              </td><td>17.60             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Merc 450SLC       </td><td>15.2              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.78              </td><td>18.00             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Cadillac Fleetwood</td><td>10.4              </td><td>8                 </td><td>472.0             </td><td>205               </td><td>2.93              </td><td>5.25              </td><td>17.98             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "<strong>spark.driver.host:</strong> '172.16.155.185'"
       ],
       "text/latex": [
-       "\\begin{tabular}{r|llllllllllll}\n",
-       " car & mpg & cyl & disp & hp & drat & wt & qsec & vs & am & gear & carb\\\\\n",
-       "\\hline\n",
-       "\t Duster 360         & 14.3               & 8                  & 360.0              & 245                & 3.21               & 3.57               & 15.84              & 0                  & 0                  & 3                  & 4                 \\\\\n",
-       "\t Merc 280C          & 17.8               & 6                  & 167.6              & 123                & 3.92               & 3.44               & 18.90              & 1                  & 0                  & 4                  & 4                 \\\\\n",
-       "\t Merc 450SE         & 16.4               & 8                  & 275.8              & 180                & 3.07               & 4.07               & 17.40              & 0                  & 0                  & 3                  & 3                 \\\\\n",
-       "\t Merc 450SL         & 17.3               & 8                  & 275.8              & 180                & 3.07               & 3.73               & 17.60              & 0                  & 0                  & 3                  & 3                 \\\\\n",
-       "\t Merc 450SLC        & 15.2               & 8                  & 275.8              & 180                & 3.07               & 3.78               & 18.00              & 0                  & 0                  & 3                  & 3                 \\\\\n",
-       "\t Cadillac Fleetwood & 10.4               & 8                  & 472.0              & 205                & 2.93               & 5.25               & 17.98              & 0                  & 0                  & 3                  & 4                 \\\\\n",
-       "\\end{tabular}\n"
+       "\\textbf{spark.driver.host:} '172.16.155.185'"
       ],
       "text/markdown": [
-       "\n",
-       "car | mpg | cyl | disp | hp | drat | wt | qsec | vs | am | gear | carb | \n",
-       "|---|---|---|---|---|---|\n",
-       "| Duster 360         | 14.3               | 8                  | 360.0              | 245                | 3.21               | 3.57               | 15.84              | 0                  | 0                  | 3                  | 4                  | \n",
-       "| Merc 280C          | 17.8               | 6                  | 167.6              | 123                | 3.92               | 3.44               | 18.90              | 1                  | 0                  | 4                  | 4                  | \n",
-       "| Merc 450SE         | 16.4               | 8                  | 275.8              | 180                | 3.07               | 4.07               | 17.40              | 0                  | 0                  | 3                  | 3                  | \n",
-       "| Merc 450SL         | 17.3               | 8                  | 275.8              | 180                | 3.07               | 3.73               | 17.60              | 0                  | 0                  | 3                  | 3                  | \n",
-       "| Merc 450SLC        | 15.2               | 8                  | 275.8              | 180                | 3.07               | 3.78               | 18.00              | 0                  | 0                  | 3                  | 3                  | \n",
-       "| Cadillac Fleetwood | 10.4               | 8                  | 472.0              | 205                | 2.93               | 5.25               | 17.98              | 0                  | 0                  | 3                  | 4                  | \n",
-       "\n",
-       "\n"
+       "**spark.driver.host:** '172.16.155.185'"
       ],
       "text/plain": [
-       "  car                mpg  cyl disp  hp  drat wt   qsec  vs am gear carb\n",
-       "1 Duster 360         14.3 8   360.0 245 3.21 3.57 15.84 0  0  3    4   \n",
-       "2 Merc 280C          17.8 6   167.6 123 3.92 3.44 18.90 1  0  4    4   \n",
-       "3 Merc 450SE         16.4 8   275.8 180 3.07 4.07 17.40 0  0  3    3   \n",
-       "4 Merc 450SL         17.3 8   275.8 180 3.07 3.73 17.60 0  0  3    3   \n",
-       "5 Merc 450SLC        15.2 8   275.8 180 3.07 3.78 18.00 0  0  3    3   \n",
-       "6 Cadillac Fleetwood 10.4 8   472.0 205 2.93 5.25 17.98 0  0  3    4   "
+       "spark.driver.host \n",
+       " \"172.16.155.185\" "
       ]
      },
      "metadata": {},
@@ -566,329 +182,7 @@
    ],
    "source": [
     "#DEPENDS\n",
-    "SparkR::head(SparkR::filter(sdf, sdf$mpg < 18))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Aggregate_data_after_grouping_by_columns'></a>\n",
-    "## 4. Aggregate data after grouping by columns\n",
-    "Spark DataFrames support a number of common functions to aggregate data after grouping. For example, you can compute the average weight of cars as a function of the number of cylinders:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>cyl</th><th scope=col>wtavg</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>8       </td><td>3.999214</td></tr>\n",
-       "\t<tr><td>4       </td><td>2.285727</td></tr>\n",
-       "\t<tr><td>6       </td><td>3.117143</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|ll}\n",
-       " cyl & wtavg\\\\\n",
-       "\\hline\n",
-       "\t 8        & 3.999214\\\\\n",
-       "\t 4        & 2.285727\\\\\n",
-       "\t 6        & 3.117143\\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "cyl | wtavg | \n",
-       "|---|---|---|\n",
-       "| 8        | 3.999214 | \n",
-       "| 4        | 2.285727 | \n",
-       "| 6        | 3.117143 | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "  cyl wtavg   \n",
-       "1 8   3.999214\n",
-       "2 4   2.285727\n",
-       "3 6   3.117143"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "SparkR::head(summarize(groupBy(sdf, sdf$cyl), wtavg = avg(sdf$wt)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also sort the output from the aggregation to determine the most popular cylinder configuration in the DataFrame:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>cyl</th><th scope=col>count</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>8 </td><td>14</td></tr>\n",
-       "\t<tr><td>4 </td><td>11</td></tr>\n",
-       "\t<tr><td>6 </td><td> 7</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|ll}\n",
-       " cyl & count\\\\\n",
-       "\\hline\n",
-       "\t 8  & 14\\\\\n",
-       "\t 4  & 11\\\\\n",
-       "\t 6  &  7\\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "cyl | count | \n",
-       "|---|---|---|\n",
-       "| 8  | 14 | \n",
-       "| 4  | 11 | \n",
-       "| 6  |  7 | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "  cyl count\n",
-       "1 8   14   \n",
-       "2 4   11   \n",
-       "3 6    7   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "car_counts <-summarize(groupBy(sdf, sdf$cyl), count = n(sdf$wt))\n",
-    "SparkR::head(arrange(car_counts, desc(car_counts$count)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Operate_on_columns'></a>\n",
-    "## 5. Operate on columns\n",
-    "SparkR provides a number of functions that you can apply directly to columns for data processing. In the following example, a basic arithmetic function converts lbs to metric tons:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>wt</th><th scope=col>wtTon</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4        </td><td>2.620            </td><td>1.17900          </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag    </td><td>2.875            </td><td>1.29375          </td></tr>\n",
-       "\t<tr><td>Datsun 710       </td><td>2.320            </td><td>1.04400          </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive   </td><td>3.215            </td><td>1.44675          </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout</td><td>3.440            </td><td>1.54800          </td></tr>\n",
-       "\t<tr><td>Valiant          </td><td>3.460            </td><td>1.55700          </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|lll}\n",
-       " car & wt & wtTon\\\\\n",
-       "\\hline\n",
-       "\t Mazda RX4         & 2.620             & 1.17900          \\\\\n",
-       "\t Mazda RX4 Wag     & 2.875             & 1.29375          \\\\\n",
-       "\t Datsun 710        & 2.320             & 1.04400          \\\\\n",
-       "\t Hornet 4 Drive    & 3.215             & 1.44675          \\\\\n",
-       "\t Hornet Sportabout & 3.440             & 1.54800          \\\\\n",
-       "\t Valiant           & 3.460             & 1.55700          \\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "car | wt | wtTon | \n",
-       "|---|---|---|---|---|---|\n",
-       "| Mazda RX4         | 2.620             | 1.17900           | \n",
-       "| Mazda RX4 Wag     | 2.875             | 1.29375           | \n",
-       "| Datsun 710        | 2.320             | 1.04400           | \n",
-       "| Hornet 4 Drive    | 3.215             | 1.44675           | \n",
-       "| Hornet Sportabout | 3.440             | 1.54800           | \n",
-       "| Valiant           | 3.460             | 1.55700           | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "  car               wt    wtTon  \n",
-       "1 Mazda RX4         2.620 1.17900\n",
-       "2 Mazda RX4 Wag     2.875 1.29375\n",
-       "3 Datsun 710        2.320 1.04400\n",
-       "4 Hornet 4 Drive    3.215 1.44675\n",
-       "5 Hornet Sportabout 3.440 1.54800\n",
-       "6 Valiant           3.460 1.55700"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "sdf$wtTon <- sdf$wt * 0.45\n",
-    "SparkR::head(select(sdf, sdf$car, sdf$wt, sdf$wtTon),6)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Run_SQL_queries_from_the_Spark_DataFrame'></a>\n",
-    "## 6. Run SQL queries from the Spark DataFrame\n",
-    "You can register a Spark DataFrame as a temporary table and then run SQL queries over the data. The `sql` function enables an application to run SQL queries programmatically and returns the result as a DataFrame:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning message:\n",
-      "“'registerTempTable' is deprecated.\n",
-      "Use 'createOrReplaceTempView' instead.\n",
-      "See help(\"Deprecated\")”Warning message:\n",
-      "“'sql(sqlContext...)' is deprecated.\n",
-      "Use 'sql(sqlQuery)' instead.\n",
-      "See help(\"Deprecated\")”"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>gear</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Porsche 914-2 </td><td>5             </td></tr>\n",
-       "\t<tr><td>Lotus Europa  </td><td>5             </td></tr>\n",
-       "\t<tr><td>Ford Pantera L</td><td>5             </td></tr>\n",
-       "\t<tr><td>Ferrari Dino  </td><td>5             </td></tr>\n",
-       "\t<tr><td>Maserati Bora </td><td>5             </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/latex": [
-       "\\begin{tabular}{r|ll}\n",
-       " car & gear\\\\\n",
-       "\\hline\n",
-       "\t Porsche 914-2  & 5             \\\\\n",
-       "\t Lotus Europa   & 5             \\\\\n",
-       "\t Ford Pantera L & 5             \\\\\n",
-       "\t Ferrari Dino   & 5             \\\\\n",
-       "\t Maserati Bora  & 5             \\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "\n",
-       "car | gear | \n",
-       "|---|---|---|---|---|\n",
-       "| Porsche 914-2  | 5              | \n",
-       "| Lotus Europa   | 5              | \n",
-       "| Ford Pantera L | 5              | \n",
-       "| Ferrari Dino   | 5              | \n",
-       "| Maserati Bora  | 5              | \n",
-       "\n",
-       "\n"
-      ],
-      "text/plain": [
-       "  car            gear\n",
-       "1 Porsche 914-2  5   \n",
-       "2 Lotus Europa   5   \n",
-       "3 Ford Pantera L 5   \n",
-       "4 Ferrari Dino   5   \n",
-       "5 Maserati Bora  5   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "registerTempTable(sdf, \"cars\")\n",
-    "\n",
-    "highgearcars <- sql(sqlContext, \"SELECT car, gear FROM cars WHERE gear >= 5\")\n",
-    "SparkR::head(highgearcars)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## That's it!\n",
-    "You successfully completed this notebook! You learned how to load a DataFrame, view and filter the data, aggregate the data, perform operations on the data in specific columns, and run SQL queries against the data. For more information about Spark, see the [Spark Quick Start Guide](http://spark.apache.org/docs/latest/quick-start.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Want to learn more?\n",
-    "### Free courses on <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu/\" rel=\"noopener noreferrer\" target=\"_blank\">Big Data University</a>: <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu\" rel=\"noopener noreferrer\" target=\"_blank\"><img src = \"https://ibm.box.com/shared/static/xomeu7dacwufkoawbg3owc8wzuezltn6.png\" width=600px> </a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Authors\n",
-    "\n",
-    "**Saeed Aghabozorgi**, PhD, is a Data Scientist in IBM with a track record of developing enterprise-level applications that substantially increases clients' ability to turn data into actionable knowledge. He is a researcher in the data mining field and an expert in developing advanced analytic methods like machine learning and statistical modelling on large data sets.\n",
-    "\n",
-    "**Polong Lin** is a Data Scientist at IBM in Canada. Under the Emerging Technologies division, Polong is responsible for educating the next generation of data scientists through Big Data University. Polong is a regular speaker in conferences and meetups, and holds an M.Sc. in Cognitive Psychology."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Copyright © 2016, 2017 Big Data University. This notebook and its source code are released under the terms of the <a href=\"https://bigdatauniversity.com/mit-license/\" rel=\"noopener noreferrer\" target=\"_blank\">MIT License</a>."
+    "unlist(sparkR.conf(\"spark.driver.host\"))"
    ]
   }
  ],
@@ -908,5 +202,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/R_Cluster1.ipynb
@@ -1,102 +1,22 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Use Spark for R to load data and run SQL queries\n",
-    "This notebook introduces basic Spark concepts and helps you to start using Spark for R.\n",
-    "\n",
-    "Some familiarity with R is recommended. This notebook runs on R with Spark 2.0.\n",
-    "\n",
-    "In this notebook, you'll use the publicly available **mtcars** data set from *Motor Trend* magazine to learn some basic R. You'll learn how to load data, create a Spark DataFrame, aggregate data, run mathematical formulas, and run SQL queries against the data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Table of contents\n",
-    "This notebook contains these main sections:\n",
-    "\n",
-    "1. [Load a DataFrame](#Load_a_DataFrame)\n",
-    "2. [Initialize an SQLContext](#Initialize_an_SQLContext)\n",
-    "3. [Create a Spark DataFrame](#Create_a_Spark_DataFrame)\n",
-    "4. [Aggregate data after grouping by columns](#Aggregate_data_after_grouping_by_columns)\n",
-    "5. [Operate on columns](#Operate_on_columns)\n",
-    "6. [Run SQL queries from the Spark DataFrame](#Run_SQL_queries_from_the_Spark_DataFrame)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Load_a_DataFrame'></a>\n",
-    "## 1. Load a DataFrame\n",
-    "A DataFrame is a distributed collection of data that is organized into named columns. The built-in R DataFrame called **mtcars** includes observations on the following 11 variables:\n",
-    "\n",
-    "`[, 1]\tmpg     Miles / (US) gallon`  \n",
-    "`[, 2]\tcyl     Number of cylinders`  \n",
-    "`[, 3]\tdisp\tDisplacement (cu. in.)`  \n",
-    "`[, 4]\thp      Gross horsepower`  \n",
-    "`[, 5]\tdrat    Rear axle ratio`  \n",
-    "`[, 6]\twt      Weight (1000 lbs)`  \n",
-    "`[, 7]\tqsec    1/4 mile time (seconds)`  \n",
-    "`[, 8]\tvs      0 = V-engine, 1 = straight engine`  \n",
-    "`[, 9]\tam      Transmission (0 = automatic, 1 = manual)`  \n",
-    "`[,10]\tgear    Number of forward gears`  \n",
-    "`[,11]\tcarb    Number of carburetors`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Preview the first 3 rows of the DataFrame by using the head() function:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
+    "collapsed": false
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th></th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><th scope=row>Mazda RX4</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.620</td><td>16.46</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
-       "\t<tr><th scope=row>Mazda RX4 Wag</th><td>21.0 </td><td>6    </td><td>160  </td><td>110  </td><td>3.90 </td><td>2.875</td><td>17.02</td><td>0    </td><td>1    </td><td>4    </td><td>4    </td></tr>\n",
-       "\t<tr><th scope=row>Datsun 710</th><td>22.8 </td><td>4    </td><td>108  </td><td> 93  </td><td>3.85 </td><td>2.320</td><td>18.61</td><td>1    </td><td>1    </td><td>4    </td><td>1    </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "              mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
-       "Mazda RX4     21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
-       "Mazda RX4 Wag 21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
-       "Datsun 710    22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1] \"Hello World\"\n"
+     ]
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "# Since this display_data would be transformed into mark down of <table></table>\n",
-    "head(mtcars, 3)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Convert the car name data, which appears in the row names, into an actual column so that Spark can read it as a column:"
+    "print(\"Hello World\")"
    ]
   },
   {
@@ -107,49 +27,35 @@
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Obtaining Spark session...\n",
+      "Spark session obtained.\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4        </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.620            </td><td>16.46            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag    </td><td>21.0             </td><td>6                </td><td>160              </td><td>110              </td><td>3.90             </td><td>2.875            </td><td>17.02            </td><td>0                </td><td>1                </td><td>4                </td><td>4                </td></tr>\n",
-       "\t<tr><td>Datsun 710       </td><td>22.8             </td><td>4                </td><td>108              </td><td> 93              </td><td>3.85             </td><td>2.320            </td><td>18.61            </td><td>1                </td><td>1                </td><td>4                </td><td>1                </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive   </td><td>21.4             </td><td>6                </td><td>258              </td><td>110              </td><td>3.08             </td><td>3.215            </td><td>19.44            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout</td><td>18.7             </td><td>8                </td><td>360              </td><td>175              </td><td>3.15             </td><td>3.440            </td><td>17.02            </td><td>0                </td><td>0                </td><td>3                </td><td>2                </td></tr>\n",
-       "\t<tr><td>Valiant          </td><td>18.1             </td><td>6                </td><td>225              </td><td>105              </td><td>2.76             </td><td>3.460            </td><td>20.22            </td><td>1                </td><td>0                </td><td>3                </td><td>1                </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "'application_1512070656800_0217'"
+      ],
+      "text/latex": [
+       "'application\\_1512070656800\\_0217'"
+      ],
+      "text/markdown": [
+       "'application_1512070656800_0217'"
       ],
       "text/plain": [
-       "  car               mpg  cyl disp hp  drat wt    qsec  vs am gear carb\n",
-       "1 Mazda RX4         21.0 6   160  110 3.90 2.620 16.46 0  1  4    4   \n",
-       "2 Mazda RX4 Wag     21.0 6   160  110 3.90 2.875 17.02 0  1  4    4   \n",
-       "3 Datsun 710        22.8 4   108   93 3.85 2.320 18.61 1  1  4    1   \n",
-       "4 Hornet 4 Drive    21.4 6   258  110 3.08 3.215 19.44 1  0  3    1   \n",
-       "5 Hornet Sportabout 18.7 8   360  175 3.15 3.440 17.02 0  0  3    2   \n",
-       "6 Valiant           18.1 6   225  105 2.76 3.460 20.22 1  0  3    1   "
+       "[1] \"application_1512070656800_0217\""
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "mtcars$car <- rownames(mtcars)\n",
-    "mtcars <- mtcars[,c(12,1:11)]\n",
-    "rownames(mtcars) <- 1:nrow(mtcars)\n",
-    "head(mtcars)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Initialize_an_SQLContext'></a>\n",
-    "## 2. Initialize an SQLContext\n",
-    "To work with a DataFrame, you need an SQLContext. You create this SQLContext by using `sparkRSQL.init(sc)`. A SparkContext named sc, which has been created for you, is used to initialize the SQLContext:"
+    "#DIFFERENT\n",
+    "SparkR:::callJMethod(SparkR:::callJMethod(sc, \"sc\"), \"applicationId\")"
    ]
   },
   {
@@ -158,18 +64,29 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/latex": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/markdown": [
+       "'2.1.1.2.6.2.0-205'"
+      ],
+      "text/plain": [
+       "[1] \"2.1.1.2.6.2.0-205\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "sqlContext <- sparkR.session(sc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Create_a_Spark_DataFrame'></a>\n",
-    "## 3. Create a Spark DataFrame\n",
-    "Using the SQLContext and the loaded local DataFrame, create a Spark DataFrame and print the schema, or structure, of the DataFrame:"
+    "#DEPENDS\n",
+    "SparkR:::callJMethod(SparkR:::callJMethod(sc, \"sc\"), \"version\")"
    ]
   },
   {
@@ -180,460 +97,92 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "root\n",
-      " |-- car: string (nullable = true)\n",
-      " |-- mpg: double (nullable = true)\n",
-      " |-- cyl: double (nullable = true)\n",
-      " |-- disp: double (nullable = true)\n",
-      " |-- hp: double (nullable = true)\n",
-      " |-- drat: double (nullable = true)\n",
-      " |-- wt: double (nullable = true)\n",
-      " |-- qsec: double (nullable = true)\n",
-      " |-- vs: double (nullable = true)\n",
-      " |-- am: double (nullable = true)\n",
-      " |-- gear: double (nullable = true)\n",
-      " |-- carb: double (nullable = true)\n"
-     ]
+     "data": {
+      "text/html": [
+       "<strong>spark.master:</strong> 'yarn'"
+      ],
+      "text/latex": [
+       "\\textbf{spark.master:} 'yarn'"
+      ],
+      "text/markdown": [
+       "**spark.master:** 'yarn'"
+      ],
+      "text/plain": [
+       "spark.master \n",
+       "      \"yarn\" "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "sdf <- createDataFrame(mtcars, schema = NULL) \n",
-    "printSchema(sdf)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Display the content of the Spark DataFrame:"
+    "masterValue <- unlist(sparkR.conf(\"spark.master\"))\n",
+    "masterValue"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
-    "scrolled": false
+    "collapsed": false
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4          </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.620              </td><td>16.46              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag      </td><td>21.0               </td><td>6                  </td><td>160.0              </td><td>110                </td><td>3.90               </td><td>2.875              </td><td>17.02              </td><td>0                  </td><td>1                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Datsun 710         </td><td>22.8               </td><td>4                  </td><td>108.0              </td><td> 93                </td><td>3.85               </td><td>2.320              </td><td>18.61              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive     </td><td>21.4               </td><td>6                  </td><td>258.0              </td><td>110                </td><td>3.08               </td><td>3.215              </td><td>19.44              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout  </td><td>18.7               </td><td>8                  </td><td>360.0              </td><td>175                </td><td>3.15               </td><td>3.440              </td><td>17.02              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Valiant            </td><td>18.1               </td><td>6                  </td><td>225.0              </td><td>105                </td><td>2.76               </td><td>3.460              </td><td>20.22              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Duster 360         </td><td>14.3               </td><td>8                  </td><td>360.0              </td><td>245                </td><td>3.21               </td><td>3.570              </td><td>15.84              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 240D          </td><td>24.4               </td><td>4                  </td><td>146.7              </td><td> 62                </td><td>3.69               </td><td>3.190              </td><td>20.00              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Merc 230           </td><td>22.8               </td><td>4                  </td><td>140.8              </td><td> 95                </td><td>3.92               </td><td>3.150              </td><td>22.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Merc 280           </td><td>19.2               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.30              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 280C          </td><td>17.8               </td><td>6                  </td><td>167.6              </td><td>123                </td><td>3.92               </td><td>3.440              </td><td>18.90              </td><td>1                  </td><td>0                  </td><td>4                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Merc 450SE         </td><td>16.4               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>4.070              </td><td>17.40              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Merc 450SL         </td><td>17.3               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.730              </td><td>17.60              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Merc 450SLC        </td><td>15.2               </td><td>8                  </td><td>275.8              </td><td>180                </td><td>3.07               </td><td>3.780              </td><td>18.00              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>3                  </td></tr>\n",
-       "\t<tr><td>Cadillac Fleetwood </td><td>10.4               </td><td>8                  </td><td>472.0              </td><td>205                </td><td>2.93               </td><td>5.250              </td><td>17.98              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Lincoln Continental</td><td>10.4               </td><td>8                  </td><td>460.0              </td><td>215                </td><td>3.00               </td><td>5.424              </td><td>17.82              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Chrysler Imperial  </td><td>14.7               </td><td>8                  </td><td>440.0              </td><td>230                </td><td>3.23               </td><td>5.345              </td><td>17.42              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Fiat 128           </td><td>32.4               </td><td>4                  </td><td> 78.7              </td><td> 66                </td><td>4.08               </td><td>2.200              </td><td>19.47              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Honda Civic        </td><td>30.4               </td><td>4                  </td><td> 75.7              </td><td> 52                </td><td>4.93               </td><td>1.615              </td><td>18.52              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Toyota Corolla     </td><td>33.9               </td><td>4                  </td><td> 71.1              </td><td> 65                </td><td>4.22               </td><td>1.835              </td><td>19.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Toyota Corona      </td><td>21.5               </td><td>4                  </td><td>120.1              </td><td> 97                </td><td>3.70               </td><td>2.465              </td><td>20.01              </td><td>1                  </td><td>0                  </td><td>3                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Dodge Challenger   </td><td>15.5               </td><td>8                  </td><td>318.0              </td><td>150                </td><td>2.76               </td><td>3.520              </td><td>16.87              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>AMC Javelin        </td><td>15.2               </td><td>8                  </td><td>304.0              </td><td>150                </td><td>3.15               </td><td>3.435              </td><td>17.30              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Camaro Z28         </td><td>13.3               </td><td>8                  </td><td>350.0              </td><td>245                </td><td>3.73               </td><td>3.840              </td><td>15.41              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Pontiac Firebird   </td><td>19.2               </td><td>8                  </td><td>400.0              </td><td>175                </td><td>3.08               </td><td>3.845              </td><td>17.05              </td><td>0                  </td><td>0                  </td><td>3                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Fiat X1-9          </td><td>27.3               </td><td>4                  </td><td> 79.0              </td><td> 66                </td><td>4.08               </td><td>1.935              </td><td>18.90              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>1                  </td></tr>\n",
-       "\t<tr><td>Porsche 914-2      </td><td>26.0               </td><td>4                  </td><td>120.3              </td><td> 91                </td><td>4.43               </td><td>2.140              </td><td>16.70              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Lotus Europa       </td><td>30.4               </td><td>4                  </td><td> 95.1              </td><td>113                </td><td>3.77               </td><td>1.513              </td><td>16.90              </td><td>1                  </td><td>1                  </td><td>5                  </td><td>2                  </td></tr>\n",
-       "\t<tr><td>Ford Pantera L     </td><td>15.8               </td><td>8                  </td><td>351.0              </td><td>264                </td><td>4.22               </td><td>3.170              </td><td>14.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>4                  </td></tr>\n",
-       "\t<tr><td>Ferrari Dino       </td><td>19.7               </td><td>6                  </td><td>145.0              </td><td>175                </td><td>3.62               </td><td>2.770              </td><td>15.50              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>6                  </td></tr>\n",
-       "\t<tr><td>Maserati Bora      </td><td>15.0               </td><td>8                  </td><td>301.0              </td><td>335                </td><td>3.54               </td><td>3.570              </td><td>14.60              </td><td>0                  </td><td>1                  </td><td>5                  </td><td>8                  </td></tr>\n",
-       "\t<tr><td>Volvo 142E         </td><td>21.4               </td><td>4                  </td><td>121.0              </td><td>109                </td><td>4.11               </td><td>2.780              </td><td>18.60              </td><td>1                  </td><td>1                  </td><td>4                  </td><td>2                  </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "<strong>spark.submit.deployMode:</strong> 'cluster'"
+      ],
+      "text/latex": [
+       "\\textbf{spark.submit.deployMode:} 'cluster'"
+      ],
+      "text/markdown": [
+       "**spark.submit.deployMode:** 'cluster'"
       ],
       "text/plain": [
-       "   car                 mpg  cyl disp  hp  drat wt    qsec  vs am gear carb\n",
-       "1  Mazda RX4           21.0 6   160.0 110 3.90 2.620 16.46 0  1  4    4   \n",
-       "2  Mazda RX4 Wag       21.0 6   160.0 110 3.90 2.875 17.02 0  1  4    4   \n",
-       "3  Datsun 710          22.8 4   108.0  93 3.85 2.320 18.61 1  1  4    1   \n",
-       "4  Hornet 4 Drive      21.4 6   258.0 110 3.08 3.215 19.44 1  0  3    1   \n",
-       "5  Hornet Sportabout   18.7 8   360.0 175 3.15 3.440 17.02 0  0  3    2   \n",
-       "6  Valiant             18.1 6   225.0 105 2.76 3.460 20.22 1  0  3    1   \n",
-       "7  Duster 360          14.3 8   360.0 245 3.21 3.570 15.84 0  0  3    4   \n",
-       "8  Merc 240D           24.4 4   146.7  62 3.69 3.190 20.00 1  0  4    2   \n",
-       "9  Merc 230            22.8 4   140.8  95 3.92 3.150 22.90 1  0  4    2   \n",
-       "10 Merc 280            19.2 6   167.6 123 3.92 3.440 18.30 1  0  4    4   \n",
-       "11 Merc 280C           17.8 6   167.6 123 3.92 3.440 18.90 1  0  4    4   \n",
-       "12 Merc 450SE          16.4 8   275.8 180 3.07 4.070 17.40 0  0  3    3   \n",
-       "13 Merc 450SL          17.3 8   275.8 180 3.07 3.730 17.60 0  0  3    3   \n",
-       "14 Merc 450SLC         15.2 8   275.8 180 3.07 3.780 18.00 0  0  3    3   \n",
-       "15 Cadillac Fleetwood  10.4 8   472.0 205 2.93 5.250 17.98 0  0  3    4   \n",
-       "16 Lincoln Continental 10.4 8   460.0 215 3.00 5.424 17.82 0  0  3    4   \n",
-       "17 Chrysler Imperial   14.7 8   440.0 230 3.23 5.345 17.42 0  0  3    4   \n",
-       "18 Fiat 128            32.4 4    78.7  66 4.08 2.200 19.47 1  1  4    1   \n",
-       "19 Honda Civic         30.4 4    75.7  52 4.93 1.615 18.52 1  1  4    2   \n",
-       "20 Toyota Corolla      33.9 4    71.1  65 4.22 1.835 19.90 1  1  4    1   \n",
-       "21 Toyota Corona       21.5 4   120.1  97 3.70 2.465 20.01 1  0  3    1   \n",
-       "22 Dodge Challenger    15.5 8   318.0 150 2.76 3.520 16.87 0  0  3    2   \n",
-       "23 AMC Javelin         15.2 8   304.0 150 3.15 3.435 17.30 0  0  3    2   \n",
-       "24 Camaro Z28          13.3 8   350.0 245 3.73 3.840 15.41 0  0  3    4   \n",
-       "25 Pontiac Firebird    19.2 8   400.0 175 3.08 3.845 17.05 0  0  3    2   \n",
-       "26 Fiat X1-9           27.3 4    79.0  66 4.08 1.935 18.90 1  1  4    1   \n",
-       "27 Porsche 914-2       26.0 4   120.3  91 4.43 2.140 16.70 0  1  5    2   \n",
-       "28 Lotus Europa        30.4 4    95.1 113 3.77 1.513 16.90 1  1  5    2   \n",
-       "29 Ford Pantera L      15.8 8   351.0 264 4.22 3.170 14.50 0  1  5    4   \n",
-       "30 Ferrari Dino        19.7 6   145.0 175 3.62 2.770 15.50 0  1  5    6   \n",
-       "31 Maserati Bora       15.0 8   301.0 335 3.54 3.570 14.60 0  1  5    8   \n",
-       "32 Volvo 142E          21.4 4   121.0 109 4.11 2.780 18.60 1  1  4    2   "
+       "spark.submit.deployMode \n",
+       "              \"cluster\" "
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "#DEPENDS\n",
-    "SparkR::head(sdf, 32)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Try different ways of retrieving subsets of the data. For example, get the first 5 values in the **mpg** column:"
+    "deployMode <- unlist(sparkR.conf(\"spark.submit.deployMode\"))\n",
+    "deployMode"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>mpg</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>21.0</td></tr>\n",
-       "\t<tr><td>21.0</td></tr>\n",
-       "\t<tr><td>22.8</td></tr>\n",
-       "\t<tr><td>21.4</td></tr>\n",
-       "\t<tr><td>18.7</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "  mpg \n",
-       "1 21.0\n",
-       "2 21.0\n",
-       "3 22.8\n",
-       "4 21.4\n",
-       "5 18.7"
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "SparkR::head(select(sdf, sdf$mpg),5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Filter the DataFrame to retain only rows with **mpg** values that are less than 18:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>mpg</th><th scope=col>cyl</th><th scope=col>disp</th><th scope=col>hp</th><th scope=col>drat</th><th scope=col>wt</th><th scope=col>qsec</th><th scope=col>vs</th><th scope=col>am</th><th scope=col>gear</th><th scope=col>carb</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Duster 360        </td><td>14.3              </td><td>8                 </td><td>360.0             </td><td>245               </td><td>3.21              </td><td>3.57              </td><td>15.84             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
-       "\t<tr><td>Merc 280C         </td><td>17.8              </td><td>6                 </td><td>167.6             </td><td>123               </td><td>3.92              </td><td>3.44              </td><td>18.90             </td><td>1                 </td><td>0                 </td><td>4                 </td><td>4                 </td></tr>\n",
-       "\t<tr><td>Merc 450SE        </td><td>16.4              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>4.07              </td><td>17.40             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Merc 450SL        </td><td>17.3              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.73              </td><td>17.60             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Merc 450SLC       </td><td>15.2              </td><td>8                 </td><td>275.8             </td><td>180               </td><td>3.07              </td><td>3.78              </td><td>18.00             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>3                 </td></tr>\n",
-       "\t<tr><td>Cadillac Fleetwood</td><td>10.4              </td><td>8                 </td><td>472.0             </td><td>205               </td><td>2.93              </td><td>5.25              </td><td>17.98             </td><td>0                 </td><td>0                 </td><td>3                 </td><td>4                 </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
+       "<strong>spark.driver.host:</strong> '172.16.156.107'"
+      ],
+      "text/latex": [
+       "\\textbf{spark.driver.host:} '172.16.156.107'"
+      ],
+      "text/markdown": [
+       "**spark.driver.host:** '172.16.156.107'"
       ],
       "text/plain": [
-       "  car                mpg  cyl disp  hp  drat wt   qsec  vs am gear carb\n",
-       "1 Duster 360         14.3 8   360.0 245 3.21 3.57 15.84 0  0  3    4   \n",
-       "2 Merc 280C          17.8 6   167.6 123 3.92 3.44 18.90 1  0  4    4   \n",
-       "3 Merc 450SE         16.4 8   275.8 180 3.07 4.07 17.40 0  0  3    3   \n",
-       "4 Merc 450SL         17.3 8   275.8 180 3.07 3.73 17.60 0  0  3    3   \n",
-       "5 Merc 450SLC        15.2 8   275.8 180 3.07 3.78 18.00 0  0  3    3   \n",
-       "6 Cadillac Fleetwood 10.4 8   472.0 205 2.93 5.25 17.98 0  0  3    4   "
+       "spark.driver.host \n",
+       " \"172.16.156.107\" "
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
     "#DEPENDS\n",
-    "SparkR::head(SparkR::filter(sdf, sdf$mpg < 18))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Aggregate_data_after_grouping_by_columns'></a>\n",
-    "## 4. Aggregate data after grouping by columns\n",
-    "Spark DataFrames support a number of common functions to aggregate data after grouping. For example, you can compute the average weight of cars as a function of the number of cylinders:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>cyl</th><th scope=col>wtavg</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>8       </td><td>3.999214</td></tr>\n",
-       "\t<tr><td>4       </td><td>2.285727</td></tr>\n",
-       "\t<tr><td>6       </td><td>3.117143</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "  cyl wtavg   \n",
-       "1 8   3.999214\n",
-       "2 4   2.285727\n",
-       "3 6   3.117143"
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "SparkR::head(summarize(groupBy(sdf, sdf$cyl), wtavg = avg(sdf$wt)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also sort the output from the aggregation to determine the most popular cylinder configuration in the DataFrame:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>cyl</th><th scope=col>count</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>8 </td><td>14</td></tr>\n",
-       "\t<tr><td>4 </td><td>11</td></tr>\n",
-       "\t<tr><td>6 </td><td> 7</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "  cyl count\n",
-       "1 8   14   \n",
-       "2 4   11   \n",
-       "3 6    7   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "car_counts <-summarize(groupBy(sdf, sdf$cyl), count = n(sdf$wt))\n",
-    "SparkR::head(arrange(car_counts, desc(car_counts$count)))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Operate_on_columns'></a>\n",
-    "## 5. Operate on columns\n",
-    "SparkR provides a number of functions that you can apply directly to columns for data processing. In the following example, a basic arithmetic function converts lbs to metric tons:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>wt</th><th scope=col>wtTon</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Mazda RX4        </td><td>2.620            </td><td>1.17900          </td></tr>\n",
-       "\t<tr><td>Mazda RX4 Wag    </td><td>2.875            </td><td>1.29375          </td></tr>\n",
-       "\t<tr><td>Datsun 710       </td><td>2.320            </td><td>1.04400          </td></tr>\n",
-       "\t<tr><td>Hornet 4 Drive   </td><td>3.215            </td><td>1.44675          </td></tr>\n",
-       "\t<tr><td>Hornet Sportabout</td><td>3.440            </td><td>1.54800          </td></tr>\n",
-       "\t<tr><td>Valiant          </td><td>3.460            </td><td>1.55700          </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "  car               wt    wtTon  \n",
-       "1 Mazda RX4         2.620 1.17900\n",
-       "2 Mazda RX4 Wag     2.875 1.29375\n",
-       "3 Datsun 710        2.320 1.04400\n",
-       "4 Hornet 4 Drive    3.215 1.44675\n",
-       "5 Hornet Sportabout 3.440 1.54800\n",
-       "6 Valiant           3.460 1.55700"
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "sdf$wtTon <- sdf$wt * 0.45\n",
-    "SparkR::head(select(sdf, sdf$car, sdf$wt, sdf$wtTon),6)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='Run_SQL_queries_from_the_Spark_DataFrame'></a>\n",
-    "## 6. Run SQL queries from the Spark DataFrame\n",
-    "You can register a Spark DataFrame as a temporary table and then run SQL queries over the data. The `sql` function enables an application to run SQL queries programmatically and returns the result as a DataFrame:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Warning message:\n",
-      "“'registerTempTable' is deprecated.\n",
-      "Use 'createOrReplaceTempView' instead.\n",
-      "See help(\"Deprecated\")”Warning message:\n",
-      "“'sql(sqlContext...)' is deprecated.\n",
-      "Use 'sql(sqlQuery)' instead.\n",
-      "See help(\"Deprecated\")”"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<thead><tr><th scope=col>car</th><th scope=col>gear</th></tr></thead>\n",
-       "<tbody>\n",
-       "\t<tr><td>Porsche 914-2 </td><td>5             </td></tr>\n",
-       "\t<tr><td>Lotus Europa  </td><td>5             </td></tr>\n",
-       "\t<tr><td>Ford Pantera L</td><td>5             </td></tr>\n",
-       "\t<tr><td>Ferrari Dino  </td><td>5             </td></tr>\n",
-       "\t<tr><td>Maserati Bora </td><td>5             </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n"
-      ],
-      "text/plain": [
-       "  car            gear\n",
-       "1 Porsche 914-2  5   \n",
-       "2 Lotus Europa   5   \n",
-       "3 Ford Pantera L 5   \n",
-       "4 Ferrari Dino   5   \n",
-       "5 Maserati Bora  5   "
-      ]
-     },
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#DEPENDS\n",
-    "registerTempTable(sdf, \"cars\")\n",
-    "\n",
-    "highgearcars <- sql(sqlContext, \"SELECT car, gear FROM cars WHERE gear >= 5\")\n",
-    "SparkR::head(highgearcars)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## That's it!\n",
-    "You successfully completed this notebook! You learned how to load a DataFrame, view and filter the data, aggregate the data, perform operations on the data in specific columns, and run SQL queries against the data. For more information about Spark, see the [Spark Quick Start Guide](http://spark.apache.org/docs/latest/quick-start.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Want to learn more?\n",
-    "### Free courses on <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu/\" rel=\"noopener noreferrer\" target=\"_blank\">Big Data University</a>: <a href=\"https://bigdatauniversity.com/courses/?utm_source=tutorial-dashdb-python&utm_medium=github&utm_campaign=bdu\" rel=\"noopener noreferrer\" target=\"_blank\"><img src = \"https://ibm.box.com/shared/static/xomeu7dacwufkoawbg3owc8wzuezltn6.png\" width=600px> </a>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Authors\n",
-    "\n",
-    "**Saeed Aghabozorgi**, PhD, is a Data Scientist in IBM with a track record of developing enterprise-level applications that substantially increases clients' ability to turn data into actionable knowledge. He is a researcher in the data mining field and an expert in developing advanced analytic methods like machine learning and statistical modelling on large data sets.\n",
-    "\n",
-    "**Polong Lin** is a Data Scientist at IBM in Canada. Under the Emerging Technologies division, Polong is responsible for educating the next generation of data scientists through Big Data University. Polong is a regular speaker in conferences and meetups, and holds an M.Sc. in Cognitive Psychology."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Copyright © 2016, 2017 Big Data University. This notebook and its source code are released under the terms of the <a href=\"https://bigdatauniversity.com/mit-license/\" rel=\"noopener noreferrer\" target=\"_blank\">MIT License</a>."
+    "unlist(sparkR.conf(\"spark.driver.host\"))"
    ]
   }
  ],
@@ -653,5 +202,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "application_1512070656800_0214"
+       "application_1512070656800_0235"
       ]
      },
      "execution_count": 2,
@@ -99,19 +99,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "yarn\n",
-      "client\n"
+      "yarn\n"
      ]
     }
    ],
    "source": [
-    "println(sc.getConf.get(\"spark.master\"))\n",
-    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
+    "println(sc.getConf.get(\"spark.master\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "client\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -138,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -154,7 +171,7 @@
        "StackTrace: "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,16 +182,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### The JAR file will be downloaded to the driver host, under path:\n",
-    "#### /hadoop/yarn/local/usercache/[username]/appcache/[appID]/[containerID]/tmp/"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -195,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -206,7 +215,7 @@
        "3.0.0b SNAPSHOT"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Client1.ipynb
@@ -11,12 +11,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "AAAA\n"
+      "Hello World\n"
      ]
     }
    ],
    "source": [
-    "println(\"AAAA\")"
+    "println(\"Hello World\")"
    ]
   },
   {
@@ -43,16 +43,9 @@
      "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "c0a95d8d-b6ed-4551-bea4-d2bb37f1dea3\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "application_1502395407456_0091"
+       "application_1512070656800_0214"
       ]
      },
      "execution_count": 2,
@@ -62,15 +55,7 @@
    ],
    "source": [
     "//DIFFERENT\n",
-    "println(sc.appName)\n",
     "sc.applicationId"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Verify the application config parameters with YARN RM web UI"
    ]
   },
   {
@@ -83,16 +68,7 @@
     {
      "data": {
       "text/plain": [
-       "conf = org.apache.spark.SparkConf@4be04e70\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "org.apache.spark.SparkConf@4be04e70"
+       "2.1.1.2.6.2.0-205"
       ]
      },
      "execution_count": 3,
@@ -102,7 +78,14 @@
    ],
    "source": [
     "//DEPENDS\n",
-    "var conf = sc.getConf"
+    "sc.version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Verify the application config parameters with YARN RM web UI"
    ]
   },
   {
@@ -122,15 +105,8 @@
     }
    ],
    "source": [
-    "println(conf.get(\"spark.master\"))\n",
-    "println(conf.get(\"spark.submit.deployMode\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Verify the host where the Kernel is running on"
+    "println(sc.getConf.get(\"spark.master\"))\n",
+    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
    ]
   },
   {
@@ -139,17 +115,25 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "172.16.156.43\n"
+     ]
+    }
+   ],
    "source": [
     "//DEPENDS\n",
-    "println(conf.get(\"spark.driver.host\"))"
+    "println(sc.getConf.get(\"spark.driver.host\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Add Jar magic"
+    "### Unique to Toree Scala kernels, test add Jar magic"
    ]
   },
   {
@@ -202,114 +186,6 @@
       "Starting download from https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar\n",
       "Finished download of lwjgl-3.0.0b.jar\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "error: error while loading Encoders, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Encoders.class)' has location not matching its contents: contains class Encoders\n",
-       "error: error while loading RowFactory, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RowFactory.class)' has location not matching its contents: contains class RowFactory\n",
-       "error: error while loading AnalysisException, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/AnalysisException.class)' has location not matching its contents: contains class AnalysisException\n",
-       "error: error while loading functions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/functions.class)' has location not matching its contents: contains class functions\n",
-       "error: error while loading DataFrameStatFunctions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameStatFunctions.class)' has location not matching its contents: contains class DataFrameStatFunctions\n",
-       "error: error while loading ForeachWriter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/ForeachWriter.class)' has location not matching its contents: contains class ForeachWriter\n",
-       "error: error while loading SaveMode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/SaveMode.class)' has location not matching its contents: contains class SaveMode\n",
-       "error: error while loading RelationalGroupedDataset, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RelationalGroupedDataset.class)' has location not matching its contents: contains class RelationalGroupedDataset\n",
-       "error: error while loading DataFrameNaFunctions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameNaFunctions.class)' has location not matching its contents: contains class DataFrameNaFunctions\n",
-       "error: error while loading Column, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Column.class)' has location not matching its contents: contains class Column\n",
-       "error: error while loading TypedColumn, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/TypedColumn.class)' has location not matching its contents: contains class TypedColumn\n",
-       "error: error while loading KeyValueGroupedDataset, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/KeyValueGroupedDataset.class)' has location not matching its contents: contains class KeyValueGroupedDataset\n",
-       "error: error while loading DataFrameWriter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameWriter.class)' has location not matching its contents: contains class DataFrameWriter\n",
-       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-hive_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/hive/package.class)' has location not matching its contents: contains package object hive\n",
-       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/api/package.class)' has location not matching its contents: contains package object api\n",
-       "error: error while loading UnsafeExternalRowSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeExternalRowSorter.class)' has location not matching its contents: contains class UnsafeExternalRowSorter\n",
-       "error: error while loading UnsafeKeyValueSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKeyValueSorter.class)' has location not matching its contents: contains class UnsafeKeyValueSorter\n",
-       "error: error while loading CacheManager, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CacheManager.class)' has location not matching its contents: contains class CacheManager\n",
-       "error: error while loading PartitionIdPassthrough, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PartitionIdPassthrough.class)' has location not matching its contents: contains class PartitionIdPassthrough\n",
-       "error: error while loading SparkSqlAstBuilder, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlAstBuilder.class)' has location not matching its contents: contains class SparkSqlAstBuilder\n",
-       "error: error while loading MapPartitionsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapPartitionsExec.class)' has location not matching its contents: contains class MapPartitionsExec\n",
-       "error: error while loading ExpandExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExpandExec.class)' has location not matching its contents: contains class ExpandExec\n",
-       "error: error while loading UnaryExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnaryExecNode.class)' has location not matching its contents: contains class UnaryExecNode\n",
-       "error: error while loading SampleExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SampleExec.class)' has location not matching its contents: contains class SampleExec\n",
-       "error: error while loading ExternalRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDD.class)' has location not matching its contents: contains class ExternalRDD\n",
-       "error: error while loading LocalTableScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalTableScanExec.class)' has location not matching its contents: contains class LocalTableScanExec\n",
-       "error: error while loading LazyIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LazyIterator.class)' has location not matching its contents: contains class LazyIterator\n",
-       "error: error while loading InSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InSubquery.class)' has location not matching its contents: contains class InSubquery\n",
-       "error: error while loading SQLExecution, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SQLExecution.class)' has location not matching its contents: contains class SQLExecution\n",
-       "error: error while loading MapGroupsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapGroupsExec.class)' has location not matching its contents: contains class MapGroupsExec\n",
-       "error: error while loading SparkSqlParser, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlParser.class)' has location not matching its contents: contains class SparkSqlParser\n",
-       "error: error while loading CoGroupedIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupedIterator.class)' has location not matching its contents: contains class CoGroupedIterator\n",
-       "error: error while loading MapElementsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapElementsExec.class)' has location not matching its contents: contains class MapElementsExec\n",
-       "error: error while loading SparkPlan, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlan.class)' has location not matching its contents: contains class SparkPlan\n",
-       "error: error while loading FileRelation, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileRelation.class)' has location not matching its contents: contains class FileRelation\n",
-       "error: error while loading UnsafeFixedWidthAggregationMap, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.class)' has location not matching its contents: contains class UnsafeFixedWidthAggregationMap\n",
-       "error: error while loading LogicalRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LogicalRDD.class)' has location not matching its contents: contains class LogicalRDD\n",
-       "error: error while loading OutputFakerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OutputFakerExec.class)' has location not matching its contents: contains class OutputFakerExec\n",
-       "error: error while loading ShuffledRowRDDPartition, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDDPartition.class)' has location not matching its contents: contains class ShuffledRowRDDPartition\n",
-       "error: error while loading RowDataSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowDataSourceScanExec.class)' has location not matching its contents: contains class RowDataSourceScanExec\n",
-       "error: error while loading SparkPlanInfo, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanInfo.class)' has location not matching its contents: contains class SparkPlanInfo\n",
-       "error: error while loading BaseLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BaseLimitExec.class)' has location not matching its contents: contains class BaseLimitExec\n",
-       "error: error while loading WholeStageCodegenExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/WholeStageCodegenExec.class)' has location not matching its contents: contains class WholeStageCodegenExec\n",
-       "error: error while loading SortExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortExec.class)' has location not matching its contents: contains class SortExec\n",
-       "error: error while loading ObjectProducerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectProducerExec.class)' has location not matching its contents: contains class ObjectProducerExec\n",
-       "error: error while loading InputAdapter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InputAdapter.class)' has location not matching its contents: contains class InputAdapter\n",
-       "error: error while loading ScalarSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ScalarSubquery.class)' has location not matching its contents: contains class ScalarSubquery\n",
-       "error: error while loading FileSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileSourceScanExec.class)' has location not matching its contents: contains class FileSourceScanExec\n",
-       "error: error while loading ProjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ProjectExec.class)' has location not matching its contents: contains class ProjectExec\n",
-       "error: error while loading RowIteratorFromScala, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorFromScala.class)' has location not matching its contents: contains class RowIteratorFromScala\n",
-       "error: error while loading RowIteratorToScala, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorToScala.class)' has location not matching its contents: contains class RowIteratorToScala\n",
-       "error: error while loading ObjectOperator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectOperator.class)' has location not matching its contents: contains class ObjectOperator\n",
-       "error: error while loading PlanLater, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanLater.class)' has location not matching its contents: contains class PlanLater\n",
-       "error: error while loading RowIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIterator.class)' has location not matching its contents: contains class RowIterator\n",
-       "error: error while loading FlatMapGroupsInRExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FlatMapGroupsInRExec.class)' has location not matching its contents: contains class FlatMapGroupsInRExec\n",
-       "error: error while loading TakeOrderedAndProjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/TakeOrderedAndProjectExec.class)' has location not matching its contents: contains class TakeOrderedAndProjectExec\n",
-       "error: error while loading AppendColumnsWithObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsWithObjectExec.class)' has location not matching its contents: contains class AppendColumnsWithObjectExec\n",
-       "error: error while loading LocalLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalLimitExec.class)' has location not matching its contents: contains class LocalLimitExec\n",
-       "error: error while loading UnionExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnionExec.class)' has location not matching its contents: contains class UnionExec\n",
-       "error: error while loading PlanSubqueries, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanSubqueries.class)' has location not matching its contents: contains class PlanSubqueries\n",
-       "error: error while loading CodegenSupport, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CodegenSupport.class)' has location not matching its contents: contains class CodegenSupport\n",
-       "error: error while loading ObjectConsumerExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectConsumerExec.class)' has location not matching its contents: contains class ObjectConsumerExec\n",
-       "error: error while loading CoalesceExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalesceExec.class)' has location not matching its contents: contains class CoalesceExec\n",
-       "error: error while loading ShuffledRowRDD, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDD.class)' has location not matching its contents: contains class ShuffledRowRDD\n",
-       "error: error while loading SubqueryExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SubqueryExec.class)' has location not matching its contents: contains class SubqueryExec\n",
-       "error: error while loading GroupedIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GroupedIterator.class)' has location not matching its contents: contains class GroupedIterator\n",
-       "error: error while loading RDDConversions, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDConversions.class)' has location not matching its contents: contains class RDDConversions\n",
-       "error: error while loading OptimizeMetadataOnlyQuery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.class)' has location not matching its contents: contains class OptimizeMetadataOnlyQuery\n",
-       "error: error while loading QueryExecution, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecution.class)' has location not matching its contents: contains class QueryExecution\n",
-       "error: error while loading LeafExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LeafExecNode.class)' has location not matching its contents: contains class LeafExecNode\n",
-       "error: error while loading CollapseCodegenStages, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollapseCodegenStages.class)' has location not matching its contents: contains class CollapseCodegenStages\n",
-       "error: error while loading QueryExecutionException, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecutionException.class)' has location not matching its contents: contains class QueryExecutionException\n",
-       "error: error while loading CoGroupExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupExec.class)' has location not matching its contents: contains class CoGroupExec\n",
-       "error: error while loading ExecSubqueryExpression, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExecSubqueryExpression.class)' has location not matching its contents: contains class ExecSubqueryExpression\n",
-       "error: error while loading BufferedRowIterator, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BufferedRowIterator.class)' has location not matching its contents: contains class BufferedRowIterator\n",
-       "error: error while loading RDDScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDScanExec.class)' has location not matching its contents: contains class RDDScanExec\n",
-       "error: error while loading AppendColumnsExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsExec.class)' has location not matching its contents: contains class AppendColumnsExec\n",
-       "error: error while loading DataSourceScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DataSourceScanExec.class)' has location not matching its contents: contains class DataSourceScanExec\n",
-       "error: error while loading SerializeFromObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SerializeFromObjectExec.class)' has location not matching its contents: contains class SerializeFromObjectExec\n",
-       "error: error while loading ExternalRDDScanExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDDScanExec.class)' has location not matching its contents: contains class ExternalRDDScanExec\n",
-       "error: error while loading CoalescedPartitioner, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalescedPartitioner.class)' has location not matching its contents: contains class CoalescedPartitioner\n",
-       "error: error while loading UnsafeKVExternalSorter, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKVExternalSorter.class)' has location not matching its contents: contains class UnsafeKVExternalSorter\n",
-       "error: error while loading SparkOptimizer, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkOptimizer.class)' has location not matching its contents: contains class SparkOptimizer\n",
-       "error: error while loading DeserializeToObjectExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DeserializeToObjectExec.class)' has location not matching its contents: contains class DeserializeToObjectExec\n",
-       "error: error while loading SparkStrategies, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategies.class)' has location not matching its contents: contains class SparkStrategies\n",
-       "error: error while loading CollectLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollectLimitExec.class)' has location not matching its contents: contains class CollectLimitExec\n",
-       "error: error while loading RangeExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RangeExec.class)' has location not matching its contents: contains class RangeExec\n",
-       "error: error while loading ReuseSubquery, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ReuseSubquery.class)' has location not matching its contents: contains class ReuseSubquery\n",
-       "error: error while loading SparkStrategy, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategy.class)' has location not matching its contents: contains class SparkStrategy\n",
-       "error: error while loading GlobalLimitExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GlobalLimitExec.class)' has location not matching its contents: contains class GlobalLimitExec\n",
-       "error: error while loading GenerateExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GenerateExec.class)' has location not matching its contents: contains class GenerateExec\n",
-       "error: error while loading UnsafeRowSerializer, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializer.class)' has location not matching its contents: contains class UnsafeRowSerializer\n",
-       "error: error while loading CachedData, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CachedData.class)' has location not matching its contents: contains class CachedData\n",
-       "error: error while loading SortPrefixUtils, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortPrefixUtils.class)' has location not matching its contents: contains class SortPrefixUtils\n",
-       "error: error while loading SparkPlanner, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanner.class)' has location not matching its contents: contains class SparkPlanner\n",
-       "error: error while loading BinaryExecNode, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BinaryExecNode.class)' has location not matching its contents: contains class BinaryExecNode\n",
-       "error: error while loading UnsafeRowSerializerInstance, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializerInstance.class)' has location not matching its contents: contains class UnsafeRowSerializerInstance\n",
-       "error: error while loading FilterExec, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FilterExec.class)' has location not matching its contents: contains class FilterExec\n",
-       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/joins/package.class)' has location not matching its contents: contains package object joins\n",
-       "error: error while loading package, class file '/usr/hdp/2.6.1.0-129/spark2/jars/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/debug/package.class)' has location not matching its contents: contains package object debug\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -337,53 +213,6 @@
    ],
    "source": [
     "org.lwjgl.Version.getVersion()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(spark.history.kerberos.keytab,none)\n",
-      "(spark.eventLog.enabled,true)\n",
-      "(spark.history.ui.port,18081)\n",
-      "(spark.driver.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
-      "(hive.metastore.warehouse.dir,file:/home/elyra/spark-warehouse/)\n",
-      "(spark.executor.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
-      "(spark.driver.appUIAddress,http://172.16.210.224:4040)\n",
-      "(spark.repl.class.uri,spark://172.16.210.224:43007/classes)\n",
-      "(spark.repl.class.outputDir,/tmp/spark-aa235d19-9a2f-4684-a177-d6cd01a5f7a5/repl-17a8484a-6a9d-4e95-8c8e-61d5537e7d42)\n",
-      "(spark.history.provider,org.apache.spark.deploy.history.FsHistoryProvider)\n",
-      "(spark.submit.deployMode,client)\n",
-      "(spark.ui.filters,org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter)\n",
-      "(spark.eventLog.dir,hdfs:///spark2-history/)\n",
-      "(spark.driver.host,172.16.210.224)\n",
-      "(spark.yarn.historyServer.address,soldier-master.fyre.ibm.com:18081)\n",
-      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib/toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
-      "(spark.yarn.secondary.jars,toree-assembly-0.2.0.dev1-incubating-SNAPSHOT.jar)\n",
-      "(spark.yarn.queue,default)\n",
-      "(spark.executor.id,driver)\n",
-      "(spark.app.name,c0a95d8d-b6ed-4551-bea4-d2bb37f1dea3)\n",
-      "(spark.driver.port,43007)\n",
-      "(spark.history.fs.logDirectory,hdfs:///spark2-history/)\n",
-      "(spark.master,yarn)\n",
-      "(spark.app.id,application_1502395407456_0091)\n",
-      "(spark.history.kerberos.principal,none)\n",
-      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_HOSTS,soldier-master.fyre.ibm.com)\n",
-      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES,http://soldier-master.fyre.ibm.com:8088/proxy/application_1502395407456_0091)\n",
-      "(spark.jars,file:/usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib/toree-launcher_2.11-0.7.0.SNAPSHOT.jar)\n"
-     ]
-    }
-   ],
-   "source": [
-    "//DEPENDS\n",
-    "sc.getConf.getAll.foreach(println)"
    ]
   }
  ],

--- a/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "application_1512070656800_0212"
+       "application_1512070656800_0234"
       ]
      },
      "execution_count": 2,
@@ -99,19 +99,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "yarn\n",
-      "cluster\n"
+      "yarn\n"
      ]
     }
    ],
    "source": [
-    "println(sc.getConf.get(\"spark.master\"))\n",
-    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
+    "println(sc.getConf.get(\"spark.master\"))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cluster\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -138,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -154,7 +171,7 @@
        "StackTrace: "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -165,16 +182,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### The JAR file will be downloaded to the driver host, under path:\n",
-    "#### /hadoop/yarn/local/usercache/[username]/appcache/[appID]/[containerID]/tmp/"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -195,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -206,7 +215,7 @@
        "3.0.0b SNAPSHOT"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Scala_Cluster1.ipynb
@@ -1,6 +1,25 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello World\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(\"Hello World\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -24,17 +43,42 @@
      "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "8f6ef355-1491-4df1-83df-f24ceade34bd\n"
-     ]
+     "data": {
+      "text/plain": [
+       "application_1512070656800_0212"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "//DIFFERENT\n",
-    "println(sc.appName)\n",
     "sc.applicationId"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.1.1.2.6.2.0-205"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "//DEPENDS\n",
+    "sc.version"
    ]
   },
   {
@@ -46,39 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "conf = org.apache.spark.SparkConf@77d62788\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "org.apache.spark.SparkConf@77d62788"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "//DEPENDS\n",
-    "var conf = sc.getConf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -93,20 +105,13 @@
     }
    ],
    "source": [
-    "println(conf.get(\"spark.master\"))\n",
-    "println(conf.get(\"spark.submit.deployMode\"))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Verify the host where the Kernel is running on"
+    "println(sc.getConf.get(\"spark.master\"))\n",
+    "println(sc.getConf.get(\"spark.submit.deployMode\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -115,25 +120,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "172.16.213.83\n"
+      "172.16.155.185\n"
      ]
     }
    ],
    "source": [
     "//DEPENDS\n",
-    "println(conf.get(\"spark.driver.host\"))"
+    "println(sc.getConf.get(\"spark.driver.host\"))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Add Jar magic"
+    "### Unique to Toree Scala kernels, test add Jar magic"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -149,7 +154,7 @@
        "StackTrace: "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -181,141 +186,11 @@
       "Starting download from https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar\n",
       "Finished download of lwjgl-3.0.0b.jar\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "error: error while loading Encoders, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Encoders.class)' has location not matching its contents: contains class Encoders\n",
-       "error: error while loading RowFactory, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RowFactory.class)' has location not matching its contents: contains class RowFactory\n",
-       "error: error while loading AnalysisException, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/AnalysisException.class)' has location not matching its contents: contains class AnalysisException\n",
-       "error: error while loading functions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/functions.class)' has location not matching its contents: contains class functions\n",
-       "error: error while loading DataFrameStatFunctions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameStatFunctions.class)' has location not matching its contents: contains class DataFrameStatFunctions\n",
-       "error: error while loading ForeachWriter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/ForeachWriter.class)' has location not matching its contents: contains class ForeachWriter\n",
-       "error: error while loading SaveMode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/SaveMode.class)' has location not matching its contents: contains class SaveMode\n",
-       "error: error while loading RelationalGroupedDataset, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/RelationalGroupedDataset.class)' has location not matching its contents: contains class RelationalGroupedDataset\n",
-       "error: error while loading DataFrameNaFunctions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameNaFunctions.class)' has location not matching its contents: contains class DataFrameNaFunctions\n",
-       "error: error while loading Column, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/Column.class)' has location not matching its contents: contains class Column\n",
-       "error: error while loading TypedColumn, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/TypedColumn.class)' has location not matching its contents: contains class TypedColumn\n",
-       "error: error while loading KeyValueGroupedDataset, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/KeyValueGroupedDataset.class)' has location not matching its contents: contains class KeyValueGroupedDataset\n",
-       "error: error while loading DataFrameWriter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/DataFrameWriter.class)' has location not matching its contents: contains class DataFrameWriter\n",
-       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-hive_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/hive/package.class)' has location not matching its contents: contains package object hive\n",
-       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/api/package.class)' has location not matching its contents: contains package object api\n",
-       "error: error while loading UnsafeExternalRowSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeExternalRowSorter.class)' has location not matching its contents: contains class UnsafeExternalRowSorter\n",
-       "error: error while loading UnsafeKeyValueSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-catalyst_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKeyValueSorter.class)' has location not matching its contents: contains class UnsafeKeyValueSorter\n",
-       "error: error while loading CacheManager, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CacheManager.class)' has location not matching its contents: contains class CacheManager\n",
-       "error: error while loading PartitionIdPassthrough, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PartitionIdPassthrough.class)' has location not matching its contents: contains class PartitionIdPassthrough\n",
-       "error: error while loading SparkSqlAstBuilder, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlAstBuilder.class)' has location not matching its contents: contains class SparkSqlAstBuilder\n",
-       "error: error while loading MapPartitionsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapPartitionsExec.class)' has location not matching its contents: contains class MapPartitionsExec\n",
-       "error: error while loading ExpandExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExpandExec.class)' has location not matching its contents: contains class ExpandExec\n",
-       "error: error while loading UnaryExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnaryExecNode.class)' has location not matching its contents: contains class UnaryExecNode\n",
-       "error: error while loading SampleExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SampleExec.class)' has location not matching its contents: contains class SampleExec\n",
-       "error: error while loading ExternalRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDD.class)' has location not matching its contents: contains class ExternalRDD\n",
-       "error: error while loading LocalTableScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalTableScanExec.class)' has location not matching its contents: contains class LocalTableScanExec\n",
-       "error: error while loading LazyIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LazyIterator.class)' has location not matching its contents: contains class LazyIterator\n",
-       "error: error while loading InSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InSubquery.class)' has location not matching its contents: contains class InSubquery\n",
-       "error: error while loading SQLExecution, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SQLExecution.class)' has location not matching its contents: contains class SQLExecution\n",
-       "error: error while loading MapGroupsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapGroupsExec.class)' has location not matching its contents: contains class MapGroupsExec\n",
-       "error: error while loading SparkSqlParser, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkSqlParser.class)' has location not matching its contents: contains class SparkSqlParser\n",
-       "error: error while loading CoGroupedIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupedIterator.class)' has location not matching its contents: contains class CoGroupedIterator\n",
-       "error: error while loading MapElementsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/MapElementsExec.class)' has location not matching its contents: contains class MapElementsExec\n",
-       "error: error while loading SparkPlan, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlan.class)' has location not matching its contents: contains class SparkPlan\n",
-       "error: error while loading FileRelation, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileRelation.class)' has location not matching its contents: contains class FileRelation\n",
-       "error: error while loading UnsafeFixedWidthAggregationMap, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeFixedWidthAggregationMap.class)' has location not matching its contents: contains class UnsafeFixedWidthAggregationMap\n",
-       "error: error while loading LogicalRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LogicalRDD.class)' has location not matching its contents: contains class LogicalRDD\n",
-       "error: error while loading OutputFakerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OutputFakerExec.class)' has location not matching its contents: contains class OutputFakerExec\n",
-       "error: error while loading ShuffledRowRDDPartition, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDDPartition.class)' has location not matching its contents: contains class ShuffledRowRDDPartition\n",
-       "error: error while loading RowDataSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowDataSourceScanExec.class)' has location not matching its contents: contains class RowDataSourceScanExec\n",
-       "error: error while loading SparkPlanInfo, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanInfo.class)' has location not matching its contents: contains class SparkPlanInfo\n",
-       "error: error while loading BaseLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BaseLimitExec.class)' has location not matching its contents: contains class BaseLimitExec\n",
-       "error: error while loading WholeStageCodegenExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/WholeStageCodegenExec.class)' has location not matching its contents: contains class WholeStageCodegenExec\n",
-       "error: error while loading SortExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortExec.class)' has location not matching its contents: contains class SortExec\n",
-       "error: error while loading ObjectProducerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectProducerExec.class)' has location not matching its contents: contains class ObjectProducerExec\n",
-       "error: error while loading InputAdapter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/InputAdapter.class)' has location not matching its contents: contains class InputAdapter\n",
-       "error: error while loading ScalarSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ScalarSubquery.class)' has location not matching its contents: contains class ScalarSubquery\n",
-       "error: error while loading FileSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FileSourceScanExec.class)' has location not matching its contents: contains class FileSourceScanExec\n",
-       "error: error while loading ProjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ProjectExec.class)' has location not matching its contents: contains class ProjectExec\n",
-       "error: error while loading RowIteratorFromScala, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorFromScala.class)' has location not matching its contents: contains class RowIteratorFromScala\n",
-       "error: error while loading RowIteratorToScala, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIteratorToScala.class)' has location not matching its contents: contains class RowIteratorToScala\n",
-       "error: error while loading ObjectOperator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectOperator.class)' has location not matching its contents: contains class ObjectOperator\n",
-       "error: error while loading PlanLater, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanLater.class)' has location not matching its contents: contains class PlanLater\n",
-       "error: error while loading RowIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RowIterator.class)' has location not matching its contents: contains class RowIterator\n",
-       "error: error while loading FlatMapGroupsInRExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FlatMapGroupsInRExec.class)' has location not matching its contents: contains class FlatMapGroupsInRExec\n",
-       "error: error while loading TakeOrderedAndProjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/TakeOrderedAndProjectExec.class)' has location not matching its contents: contains class TakeOrderedAndProjectExec\n",
-       "error: error while loading AppendColumnsWithObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsWithObjectExec.class)' has location not matching its contents: contains class AppendColumnsWithObjectExec\n",
-       "error: error while loading LocalLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LocalLimitExec.class)' has location not matching its contents: contains class LocalLimitExec\n",
-       "error: error while loading UnionExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnionExec.class)' has location not matching its contents: contains class UnionExec\n",
-       "error: error while loading PlanSubqueries, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/PlanSubqueries.class)' has location not matching its contents: contains class PlanSubqueries\n",
-       "error: error while loading CodegenSupport, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CodegenSupport.class)' has location not matching its contents: contains class CodegenSupport\n",
-       "error: error while loading ObjectConsumerExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ObjectConsumerExec.class)' has location not matching its contents: contains class ObjectConsumerExec\n",
-       "error: error while loading CoalesceExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalesceExec.class)' has location not matching its contents: contains class CoalesceExec\n",
-       "error: error while loading ShuffledRowRDD, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ShuffledRowRDD.class)' has location not matching its contents: contains class ShuffledRowRDD\n",
-       "error: error while loading SubqueryExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SubqueryExec.class)' has location not matching its contents: contains class SubqueryExec\n",
-       "error: error while loading GroupedIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GroupedIterator.class)' has location not matching its contents: contains class GroupedIterator\n",
-       "error: error while loading RDDConversions, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDConversions.class)' has location not matching its contents: contains class RDDConversions\n",
-       "error: error while loading OptimizeMetadataOnlyQuery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/OptimizeMetadataOnlyQuery.class)' has location not matching its contents: contains class OptimizeMetadataOnlyQuery\n",
-       "error: error while loading QueryExecution, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecution.class)' has location not matching its contents: contains class QueryExecution\n",
-       "error: error while loading LeafExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/LeafExecNode.class)' has location not matching its contents: contains class LeafExecNode\n",
-       "error: error while loading CollapseCodegenStages, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollapseCodegenStages.class)' has location not matching its contents: contains class CollapseCodegenStages\n",
-       "error: error while loading QueryExecutionException, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/QueryExecutionException.class)' has location not matching its contents: contains class QueryExecutionException\n",
-       "error: error while loading CoGroupExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoGroupExec.class)' has location not matching its contents: contains class CoGroupExec\n",
-       "error: error while loading ExecSubqueryExpression, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExecSubqueryExpression.class)' has location not matching its contents: contains class ExecSubqueryExpression\n",
-       "error: error while loading BufferedRowIterator, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BufferedRowIterator.class)' has location not matching its contents: contains class BufferedRowIterator\n",
-       "error: error while loading RDDScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RDDScanExec.class)' has location not matching its contents: contains class RDDScanExec\n",
-       "error: error while loading AppendColumnsExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/AppendColumnsExec.class)' has location not matching its contents: contains class AppendColumnsExec\n",
-       "error: error while loading DataSourceScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DataSourceScanExec.class)' has location not matching its contents: contains class DataSourceScanExec\n",
-       "error: error while loading SerializeFromObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SerializeFromObjectExec.class)' has location not matching its contents: contains class SerializeFromObjectExec\n",
-       "error: error while loading ExternalRDDScanExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ExternalRDDScanExec.class)' has location not matching its contents: contains class ExternalRDDScanExec\n",
-       "error: error while loading CoalescedPartitioner, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CoalescedPartitioner.class)' has location not matching its contents: contains class CoalescedPartitioner\n",
-       "error: error while loading UnsafeKVExternalSorter, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeKVExternalSorter.class)' has location not matching its contents: contains class UnsafeKVExternalSorter\n",
-       "error: error while loading SparkOptimizer, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkOptimizer.class)' has location not matching its contents: contains class SparkOptimizer\n",
-       "error: error while loading DeserializeToObjectExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/DeserializeToObjectExec.class)' has location not matching its contents: contains class DeserializeToObjectExec\n",
-       "error: error while loading SparkStrategies, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategies.class)' has location not matching its contents: contains class SparkStrategies\n",
-       "error: error while loading CollectLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CollectLimitExec.class)' has location not matching its contents: contains class CollectLimitExec\n",
-       "error: error while loading RangeExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/RangeExec.class)' has location not matching its contents: contains class RangeExec\n",
-       "error: error while loading ReuseSubquery, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/ReuseSubquery.class)' has location not matching its contents: contains class ReuseSubquery\n",
-       "error: error while loading SparkStrategy, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkStrategy.class)' has location not matching its contents: contains class SparkStrategy\n",
-       "error: error while loading GlobalLimitExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GlobalLimitExec.class)' has location not matching its contents: contains class GlobalLimitExec\n",
-       "error: error while loading GenerateExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/GenerateExec.class)' has location not matching its contents: contains class GenerateExec\n",
-       "error: error while loading UnsafeRowSerializer, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializer.class)' has location not matching its contents: contains class UnsafeRowSerializer\n",
-       "error: error while loading CachedData, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/CachedData.class)' has location not matching its contents: contains class CachedData\n",
-       "error: error while loading SortPrefixUtils, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SortPrefixUtils.class)' has location not matching its contents: contains class SortPrefixUtils\n",
-       "error: error while loading SparkPlanner, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/SparkPlanner.class)' has location not matching its contents: contains class SparkPlanner\n",
-       "error: error while loading BinaryExecNode, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/BinaryExecNode.class)' has location not matching its contents: contains class BinaryExecNode\n",
-       "error: error while loading UnsafeRowSerializerInstance, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/UnsafeRowSerializerInstance.class)' has location not matching its contents: contains class UnsafeRowSerializerInstance\n",
-       "error: error while loading FilterExec, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/FilterExec.class)' has location not matching its contents: contains class FilterExec\n",
-       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/joins/package.class)' has location not matching its contents: contains package object joins\n",
-       "error: error while loading package, class file '/hadoop/yarn/local/filecache/10/spark2-hdp-yarn-archive.tar.gz/spark-sql_2.11-2.1.1.2.6.1.0-129.jar(org/apache/spark/sql/execution/debug/package.class)' has location not matching its contents: contains package object debug\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
     "//DEPENDS\n",
     "%addjar -f https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.0.0b/lwjgl-3.0.0b.jar"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "3.0.0b SNAPSHOT"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "org.lwjgl.Version.getVersion()"
    ]
   },
   {
@@ -326,46 +201,18 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(spark.history.kerberos.keytab,none)\n",
-      "(spark.eventLog.enabled,true)\n",
-      "(spark.app.id,application_1502395407456_0079)\n",
-      "(spark.submit.deployMode,cluster)\n",
-      "(spark.app.name,8f6ef355-1491-4df1-83df-f24ceade34bd)\n",
-      "(spark.yarn.submit.waitAppCompletion,false)\n",
-      "(spark.history.ui.port,18081)\n",
-      "(spark.driver.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
-      "(spark.executor.extraLibraryPath,/usr/hdp/current/hadoop-client/lib/native:/usr/hdp/current/hadoop-client/lib/native/Linux-amd64-64)\n",
-      "(spark.repl.class.uri,spark://172.16.213.83:43772/classes)\n",
-      "(spark.repl.class.outputDir,/hadoop/yarn/local/usercache/elyra/appcache/application_1502395407456_0079/spark-c995b736-dd47-40aa-ab16-9a0dee598c56/repl-450f417a-f048-4a76-aa58-a0bc0c742b7f)\n",
-      "(spark.history.provider,org.apache.spark.deploy.history.FsHistoryProvider)\n",
-      "(spark.yarn.dist.jars,file:/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/lib/toree-assembly-luciano.jar)\n",
-      "(spark.ui.filters,org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter)\n",
-      "(spark.eventLog.dir,hdfs:///spark2-history/)\n",
-      "(spark.yarn.secondary.jars,toree-assembly-luciano.jar)\n",
-      "(spark.yarn.app.container.log.dir,/hadoop/yarn/log/application_1502395407456_0079/container_e01_1502395407456_0079_01_000001)\n",
-      "(spark.driver.host,172.16.213.83)\n",
-      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_URI_BASES,http://soldier-master.fyre.ibm.com:8088/proxy/application_1502395407456_0079)\n",
-      "(spark.yarn.historyServer.address,soldier-master.fyre.ibm.com:18081)\n",
-      "(spark.yarn.app.id,application_1502395407456_0079)\n",
-      "(spark.yarn.queue,default)\n",
-      "(spark.executor.id,driver)\n",
-      "(spark.history.fs.logDirectory,hdfs:///spark2-history/)\n",
-      "(spark.master,yarn)\n",
-      "(spark.ui.port,0)\n",
-      "(spark.history.kerberos.principal,none)\n",
-      "(spark.org.apache.hadoop.yarn.server.webproxy.amfilter.AmIpFilter.param.PROXY_HOSTS,soldier-master.fyre.ibm.com)\n",
-      "(spark.yarn.am.waitTime,1d)\n",
-      "(spark.driver.port,43772)\n",
-      "(hive.metastore.warehouse.dir,file:/hadoop/yarn/local/usercache/elyra/appcache/application_1502395407456_0079/container_e01_1502395407456_0079_01_000001/spark-warehouse)\n"
-     ]
+     "data": {
+      "text/plain": [
+       "3.0.0b SNAPSHOT"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "//DEPENDS\n",
-    "sc.getConf.getAll.foreach(println)"
+    "org.lwjgl.Version.getVersion()"
    ]
   }
  ],

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -82,7 +82,8 @@ class ElyraClient(object):
             code_cell_count = 1
             for code_cell in nb_code_entity.get_all_code_cell():
                 if code_cell.is_executed():
-                    print("---{})\n {}".format(code_cell_count, code_cell.get_source_for_execution()))
+                    print("---{}) {}\n{}".format(code_cell_count, code_cell,
+                                                 code_cell.get_source_for_execution()))
                     code_cell_count += 1
                     code_source = code_cell.get_source_for_execution()
                     ws.send(ElyraClient.new_code_message(code_source))

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -1,6 +1,6 @@
 from tornado.escape import json_encode, json_decode, url_escape
 from uuid import uuid4
-from nb_entity import NBCodeCell, NBCodeEntity
+from nb_entity import NBCodeCell
 import websocket
 from collections import deque
 
@@ -29,7 +29,6 @@ class ElyraClient(object):
         # Ask Elyra to create a new kernel based on kernel spec name, and return the kernel id if successfully created.
         kernel_id = None
         kernel_spec_name = nb_code_entity.kernel_spec_name
-        file_name = nb_code_entity.file_name
         response = requests.post(self.http_api_endpoint, data=json_encode({'name': kernel_spec_name, 'env' : {'KERNEL_USERNAME': self.username}}))
         if response.status_code == 201:
             json_data = response.json()
@@ -76,11 +75,17 @@ class ElyraClient(object):
     def execute_nb_code_entity(self, nb_code_entity):
         # Execute all code cells in a notebook code entity, get the response message in JSON format,
         # and return all code cells parsed by messages in a list.
-        ws = websocket.create_connection(self.get_ws_kernel_endpoint(nb_code_entity.kernel_id))
+        ws_url = self.get_ws_kernel_endpoint(nb_code_entity.kernel_id)
+        ws = websocket.create_connection(url=ws_url)
+        print("Connection created for web socket {}".format(ws_url))
         message_code_cell_list = list([])
         try:
+            code_cell_count = 1
             for code_cell in nb_code_entity.get_all_code_cell():
                 if code_cell.is_executed():
+                    print("---{}) {}".format(code_cell_count, code_cell))
+                    print("{}".format(code_cell.get_source_for_execution()))
+                    code_cell_count += 1
                     code_source = code_cell.get_source_for_execution()
                     ws.send(ElyraClient.new_code_message(code_source))
                     target_queue = code_cell.get_target_output_type_queue()

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 from nb_entity import NBCodeCell
 import websocket
 from collections import deque
-
 import requests
 
 
@@ -83,8 +82,7 @@ class ElyraClient(object):
             code_cell_count = 1
             for code_cell in nb_code_entity.get_all_code_cell():
                 if code_cell.is_executed():
-                    print("---{}) {}".format(code_cell_count, code_cell))
-                    print("{}".format(code_cell.get_source_for_execution()))
+                    print("---{})\n {}".format(code_cell_count, code_cell.get_source_for_execution()))
                     code_cell_count += 1
                     code_source = code_cell.get_source_for_execution()
                     ws.send(ElyraClient.new_code_message(code_source))

--- a/enterprise_gateway/itests/src/itest_notebook.py
+++ b/enterprise_gateway/itests/src/itest_notebook.py
@@ -29,6 +29,8 @@ class NotebookTestCase(TestCase):
 
     def execute_codes(self, nb_code_entity):
         nb_code_entity.kernel_id = self.elyra_client.create_new_kernel(nb_code_entity)
+        self.test_count += 1
+        print("\n{}. {}".format(self.test_count, nb_code_entity))
         test_code_cell_output_list = None
         if nb_code_entity.kernel_id:
             try:
@@ -43,8 +45,8 @@ class NotebookTestCase(TestCase):
             return test_code_cell_output_list
 
     def execute_and_assert(self, nb_code_entity):
-        print("Begin testing...({})".format(nb_code_entity))
         test_code_cell_list = self.execute_codes(nb_code_entity)
+        print("\nFinish execution of codes, now compare/assert")
         self.assertIsNotNone(test_code_cell_list)
         self.assertEqual(len(test_code_cell_list), len(nb_code_entity.code_cell_list))
         index = 0
@@ -52,14 +54,15 @@ class NotebookTestCase(TestCase):
             if real_code_cell.is_executed() and not real_code_cell.is_output_empty():
                 test_output = test_code_cell_list[index]
                 self.assertIsNotNone(test_output)
-                test_output = test_output.seralize_output()
-                real_output = real_code_cell.seralize_output()
                 assert_code = NotebookTestCase.get_assert_code(real_code_cell.get_first_line_code())
                 try:
-                    if assert_code == 0:
-                        self.assertEqual(test_output, real_output)
-                    elif assert_code == 1:
-                        self.assertNotEqual(test_output, real_output)
+                    if assert_code != 2:
+                        test_output = test_output.seralize_output()
+                        real_output = real_code_cell.seralize_output()
+                        if assert_code == 0:
+                            self.assertEqual(test_output, real_output)
+                        elif assert_code == 1:
+                            self.assertNotEqual(test_output, real_output)
                 except Exception as e:
                     print("===================================")
                     print(e.message)
@@ -70,11 +73,11 @@ class NotebookTestCase(TestCase):
                     if not self.continue_when_error:
                         sys.exit(-1)
             index += 1
-        print("Testing completed: ({})".format(nb_code_entity))
-
+        print("Testing completed: {}".format(nb_code_entity))
 
     def test_kernels_batch(self):
-        print("Begin testing batch of {} notebooks...".format(len(self.nb_entities_list)))
+        self.test_count = 0
+        print("Begin testing batch of {} notebook(s)...\n".format(len(self.nb_entities_list)))
         for nb_code_entity in self.nb_entities_list:
             self.execute_and_assert(nb_code_entity)
-        print("Batch completed.")
+        print("\nBatch completed.")

--- a/enterprise_gateway/itests/src/itest_notebook.py
+++ b/enterprise_gateway/itests/src/itest_notebook.py
@@ -55,10 +55,10 @@ class NotebookTestCase(TestCase):
                 test_output = test_code_cell_list[index]
                 self.assertIsNotNone(test_output)
                 assert_code = NotebookTestCase.get_assert_code(real_code_cell.get_first_line_code())
+                test_output = test_output.seralize_output()
+                real_output = real_code_cell.seralize_output()
                 try:
                     if assert_code != 2:
-                        test_output = test_output.seralize_output()
-                        real_output = real_code_cell.seralize_output()
                         if assert_code == 0:
                             self.assertEqual(test_output, real_output)
                         elif assert_code == 1:

--- a/enterprise_gateway/itests/src/nb_entity.py
+++ b/enterprise_gateway/itests/src/nb_entity.py
@@ -108,7 +108,7 @@ class NBCodeCell(object):
         return self.execute_count is not None
 
     def get_source_for_execution(self):
-        # The cell's source can have multiple lines of codes, but here return the source as a single string,
+        # A cell's source can have multiple lines of code, but here returns the source as a single string,
         # since executing a multi-line code v.s. line by line may generate different results.
         return "".join(self.code_source_list)
 
@@ -132,8 +132,7 @@ class NBCodeCell(object):
         return target_output_type_queue
 
     def __repr__(self):
-        return "Execution_count {}, {} lines of codes, {} outputs".format(
-            self.execute_count, len(self.code_source_list), len(self.code_output_list))
+        return "{} line(s) of code, {} output(s)".format(len(self.code_source_list), len(self.code_output_list))
 
     @staticmethod
     def parse_output_from_notebook(nb_cell_json):

--- a/enterprise_gateway/itests/src/nb_entity.py
+++ b/enterprise_gateway/itests/src/nb_entity.py
@@ -2,11 +2,7 @@
 
 import os
 import json
-import sys
 from collections import deque
-
-# reload(sys)
-# sys.setdefaultencoding('utf8')
 
 
 class CodeCellOutput(object):
@@ -33,15 +29,25 @@ class CodeCellOutput(object):
         return None
 
     def seralize(self):
+        output_list = list()
         if type(self.output) is dict:
-            for k, v in self.output.items():
+            # in the case of dict type data, the keys might be in arbitrary order
+            # so here sort the key and serialize values in order so as to compare the values by the order of keys
+            sorted_key_list = self.output.keys()
+            sorted_key_list.sort()
+            for k in sorted_key_list:
+                output_list.append(str(k))
+                v = self.output[k]
                 if type(v) is list:
-                    v = "".join(v)
-                    self.output[k] = v
+                    output_list.append("".join(v))
+                else:
+                    output_list.append(str(v))
         elif type(self.output) is list:
-            self.output = "".join(self.output)
+            output_list = self.output
+        else:
+            output_list.append(self.output)
 
-        output = "".join(self.output) if type(self.output) is list else self.output
+        output = "".join(output_list)
         return "{}:\n{}".format(self.__class__.__name__, output)
 
 


### PR DESCRIPTION
Related to issue #30 

Currently the content of each language's notebook is not consistent with other language, and in order to make us easier to compare the testing for each kernel, I normalized those notebooks so their contents are almost the same (Except for Scala kernels since we need to test `Toree magic`).

Also, now itest supports printing each code-cell/step of each notebook so when get stuck, we could detect which code cell might be the reason.