### PR TITLE
First version implementation of impersonation integration test

### DIFF
--- a/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
+++ b/enterprise_gateway/itests/notebooks/Python_Client1.ipynb
@@ -39,7 +39,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "application_1512070656800_0215\n"
+      "application_1512070656800_0265\n"
      ]
     }
    ],
@@ -129,13 +129,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "172.16.156.107\n"
+      "172.16.155.185\n"
      ]
     }
    ],
    "source": [
     "# DEPENDS\n",
     "print sc.getConf().get(\"spark.driver.host\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "elyra\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# IMPERSONATION\n",
+    "!whoami"
    ]
   }
  ],

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -52,6 +52,7 @@ class ElyraClient(object):
         Here only find those target message type and return its content in a list.
         """
         message_json_list = list([])
+        ws.settimeout(60)
         while target_msg_type_queue:
             try:
                 message = ws.recv()

--- a/enterprise_gateway/itests/src/elyra_client.py
+++ b/enterprise_gateway/itests/src/elyra_client.py
@@ -28,7 +28,10 @@ class ElyraClient(object):
         # Ask Elyra to create a new kernel based on kernel spec name, and return the kernel id if successfully created.
         kernel_id = None
         kernel_spec_name = nb_code_entity.kernel_spec_name
-        response = requests.post(self.http_api_endpoint, data=json_encode({'name': kernel_spec_name, 'env' : {'KERNEL_USERNAME': self.username}}))
+        json_data = {'name': kernel_spec_name}
+        if self.username is not None:
+            json_data['env'] = {'KERNEL_USERNAME': self.username}
+        response = requests.post(self.http_api_endpoint, data=json_encode(json_data))
         if response.status_code == 201:
             json_data = response.json()
             kernel_id = json_data.get("id")

--- a/enterprise_gateway/itests/src/itest_notebook.py
+++ b/enterprise_gateway/itests/src/itest_notebook.py
@@ -72,6 +72,7 @@ class NotebookTestCase(TestCase):
                             # and self.impersonation_username is not None
                             test_username = test_output.code_output_list[0].raw_output.get('text')
                             self.assertIsNotNone(test_username)
+                            # the raw output is a dict e.g. {'text': 'elyra\r\n', ...}, so here replace the \r\n
                             test_username = str(test_username).replace("\r\n", "")
                             self.assertEqual(test_username, self.impersonation_username)
                 except Exception as e:

--- a/enterprise_gateway/itests/src/main.py
+++ b/enterprise_gateway/itests/src/main.py
@@ -13,8 +13,8 @@ def parse_arg():
     parser.add_argument('--notebook_dir', default='../notebooks')
     parser.add_argument('--continue_when_error', default=True)
     parser.add_argument('--host', default='localhost:8888')
-    parser.add_argument('--username', default='root')
-    parser.add_argument('--impersonation_username', default=None)
+    parser.add_argument('--username', default=None)
+    parser.add_argument('--enforce_impersonation', default=False)
 
     return parser.parse_args()
 
@@ -40,8 +40,10 @@ def init_nb_test_case(args):
                 if not target_kernels or nb_entity.kernel_spec_name in target_kernels:
                     nb_entities_list.append(nb_entity)
 
-    return NotebookTestCase(method, nb_entities_list, args.continue_when_error,
-                            args.host, args.username, args.impersonation_username)
+    if args.enforce_impersonation is not True:
+        args.enforce_impersonation = False
+
+    return NotebookTestCase(method, nb_entities_list, **args.__dict__)
 
 
 if __name__ == '__main__':

--- a/enterprise_gateway/itests/src/main.py
+++ b/enterprise_gateway/itests/src/main.py
@@ -14,6 +14,7 @@ def parse_arg():
     parser.add_argument('--continue_when_error', default=True)
     parser.add_argument('--host', default='localhost:8888')
     parser.add_argument('--username', default='root')
+    parser.add_argument('--impersonation_username', default=None)
 
     return parser.parse_args()
 
@@ -39,7 +40,8 @@ def init_nb_test_case(args):
                 if not target_kernels or nb_entity.kernel_spec_name in target_kernels:
                     nb_entities_list.append(nb_entity)
 
-    return NotebookTestCase(method, nb_entities_list, args.continue_when_error, args.host, args.username)
+    return NotebookTestCase(method, nb_entities_list, args.continue_when_error,
+                            args.host, args.username, args.impersonation_username)
 
 
 if __name__ == '__main__':

--- a/enterprise_gateway/itests/src/nb_entity.py
+++ b/enterprise_gateway/itests/src/nb_entity.py
@@ -33,8 +33,7 @@ class CodeCellOutput(object):
         if type(self.output) is dict:
             # in the case of dict type data, the keys might be in arbitrary order
             # so here sort the key and serialize values in order so as to compare the values by the order of keys
-            sorted_key_list = self.output.keys()
-            sorted_key_list.sort()
+            sorted_key_list = sorted(self.output.keys())
             for k in sorted_key_list:
                 output_list.append(str(k))
                 v = self.output[k]


### PR DESCRIPTION
Related to issue #238 

Now we could do impersonation test by providing the `impersonation_username` flag with the target username, e.g. `bob`. Here is the logic:

1. For python client notebook, the newly added code cell `!whoami` would be executed
2. The first line of that code cell should contain `IMPERSONATION`, so the assert code would be returned as 3
3. If the assert code is 3, and the variable `impersonation_username` is not `None` in Python, then the output of the `!whoami` code cell would be compared with the `impersonation_username`
4. If they are the same, then it is a pass test case


Some other things to notice here:
1) It actually doesn't matter what output would be returned from the code cell of `!whoami` on the python client notebook file. The only thing matters here is if the `impersonation_username` is the same as the output or not. Hence, unlike the case of assert code 0 and 1, there is no comparison between the `test_output_str` and `real_output_str`.
2) Since this only needs to be done once for all notebook kernels, it is redundant to do the same test in either R or scala kernel. So here only the Python client notebook has this `!whoami` code cell. If we want to add this code cell to R or scala kernel anyway, might need to change the syntax e.g. in Toree scala using Toree magic (if provided).