### PR TITLE
Fix R-kernel to show kernel ID as app name in YARN RM

### DIFF
--- a/etc/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/etc/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -37,6 +37,7 @@ sparkSessionFn <- local({
 
          sparkSession <- SparkR::sparkR.session(
                                         sparkHome=Sys.getenv("SPARK_HOME"),
+                                        appName=Sys.getenv("KERNEL_ID"),
                                         sparkConfig=sparkConfigList);
          sparkSession
        }
@@ -55,6 +56,7 @@ sparkContextFn <- local({
 
         sparkContext <- SparkR:::sparkR.sparkContext(
                                           sparkHome=Sys.getenv("SPARK_HOME"),
+                                          appName=Sys.getenv("KERNEL_ID"),
                                           sparkEnvirMap=SparkR:::convertNamedListToEnv(sparkConfigList))
 
         message ("Spark session obtained.")


### PR DESCRIPTION
Updated the R launcher script to include Kernel ID instead of "SparkR" as application name in YARN resource manager