### PR TITLE
Enable SSH tunneling by default

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -248,7 +248,7 @@ JupyterWebsocketPersonality options
 
 ### Addtional supported environment variables
 ```
-  EG_ENABLE_TUNNELING=False 
+  EG_ENABLE_TUNNELING=True
       Indicates whether tunneling (via ssh) of the kernel and communication ports
       is enabled (True) or not (False).   
         
@@ -295,24 +295,23 @@ The following environment variables may be useful for troubleshooting:
 
 ### Per-kernel Configuration Overrides
 As mentioned in the overview of [Process Proxy Configuration](system-architecture.html#process-proxy-configuration)
-capabilities, it's possible to override or amend specific system-level configuration values on a per-kernel basis. 
+capabilities, it's possible to override or amend specific system-level configuration values on a per-kernel basis.
 The following enumerates the set of per-kernel configuration overrides:
 
-* `remote_hosts`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.remote_hosts`. 
-Any values specified in the config dictionary override the globally defined values.  These apply to all 
+* `remote_hosts`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.remote_hosts`.
+Any values specified in the config dictionary override the globally defined values.  These apply to all
 `DistributedProcessProxy` kernels.
-* `yarn_endpoint`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.yarn_endpoint`. 
-Any values specified in the config dictionary override the globally defined values.  These apply to all 
-`YarnClusterProcessProxy` kernels.  Note that you'll likely be required to specify a different `HADOOP_CONF_DIR` 
+* `yarn_endpoint`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.yarn_endpoint`.
+Any values specified in the config dictionary override the globally defined values.  These apply to all
+`YarnClusterProcessProxy` kernels.  Note that you'll likely be required to specify a different `HADOOP_CONF_DIR`
 setting in the kernel.json's `env` stanza in order of the `spark-submit` command to target the appropriate YARN cluster.
-* `authorized_users`: This process proxy configuration entry can be used to override 
-`--EnterpriseGatewayApp.authorized_users`.  Any values specified in the config dictionary override the globally 
-defined values.  These values apply to **all** process-proxy kernels, including the default `LocalProcessProxy`.  Note 
-that the typical use-case for this value is to not set `--EnterpriseGatewayApp.authorized_users` at the global level, 
+* `authorized_users`: This process proxy configuration entry can be used to override
+`--EnterpriseGatewayApp.authorized_users`.  Any values specified in the config dictionary override the globally
+defined values.  These values apply to **all** process-proxy kernels, including the default `LocalProcessProxy`.  Note
+that the typical use-case for this value is to not set `--EnterpriseGatewayApp.authorized_users` at the global level,
 but then restrict access at the kernel level.
-* `unauthorized_users`: This process proxy configuration entry can be used to **_amend_** 
-`--EnterpriseGatewayApp.unauthorized_users`.  Any values specified in the config dictionary are **added** to the 
-globally defined values.  As a result, once a user is denied access at the global level, they will _always be denied 
-access at the kernel level_.  These values apply to **all** process-proxy kernels, including the default 
-`LocalProcessProxy`.  
-
+* `unauthorized_users`: This process proxy configuration entry can be used to **_amend_**
+`--EnterpriseGatewayApp.unauthorized_users`.  Any values specified in the config dictionary are **added** to the
+globally defined values.  As a result, once a user is denied access at the global level, they will _always be denied
+access at the kernel level_.  These values apply to **all** process-proxy kernels, including the default
+`LocalProcessProxy`.

--- a/docs/source/getting-started-security.md
+++ b/docs/source/getting-started-security.md
@@ -46,13 +46,17 @@ slightly different.  This allows the administrator to discern from which authori
 
 Failures stemming from _inclusion_ in the `unauthorized_users` list will include text similar to the following:
 
-`User 'bob' is not authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure 
-KERNEL_USERNAME is set to an appropriate value and retry the request.`
+```
+User 'bob' is not authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure
+KERNEL_USERNAME is set to an appropriate value and retry the request.
+```
 
 Failures stemming from _exclusion_ from a non-empty `authorized_users` list will include text similar to the following:
 
-`User 'bob' is not in the set of users authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure 
-KERNEL_USERNAME is set to an appropriate value and retry the request.`
+```
+User 'bob' is not in the set of users authorized to start kernel 'Spark - Python (YARN Client Mode)'. Ensure
+KERNEL_USERNAME is set to an appropriate value and retry the request.
+```
 
 ### User Impersonation
 
@@ -64,7 +68,8 @@ information: `EG_IMPERSONATION_ENABLED` and `KERNEL_USERNAME`.
 `EG_IMPERSONATION_ENABLED` indicates the intention that user impersonation should be performed and is conveyed via
 the command-line boolean option `EnterpriseGatewayApp.impersonation_enabled` (default = False).  This value is then
 set into the environment used to launch the kernel, where `run.sh` then acts on it - performing the appropriate logic
-to trigger user impersonation when True.  As a result, it is important that the contents of kernelspecs also be secure and trusted.
+to trigger user impersonation when True.  As a result, it is important that the contents of kernelspecs also be secure
+and trusted.
 
 `KERNEL_USERNAME` is also conveyed within the environment of the kernel launch sequence where 
 its value is used to indicate the user that should be impersonated.
@@ -72,15 +77,17 @@ its value is used to indicate the user that should be impersonated.
 ##### Impersonation in YARN Cluster Mode
 The recommended approach for performing user impersonation when the kernel is launched using the YARN resource manager
 is to configure the `spark-submit` command within 
-[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh) to use the `--proxy-user ${KERNEL_USERNAME}` option.  This YARN option 
-requires that kerberos be configured within the cluster.  Please refer to the 
+[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_cluster/bin/run.sh)
+to use the `--proxy-user ${KERNEL_USERNAME}` option.  This YARN option  requires that kerberos be configured within the
+cluster.  Please refer to the
 [Hadoop documentation](https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html) 
 regarding the proper configuration of `--proxy-user`.
 
 ##### Impersonation in Standalone or YARN Client Mode
 Impersonation performed in standalone or YARN cluster modes tends to take the form of using `sudo` to perform the 
 kernel launch as the target user.  This can also be configured within the 
-[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_client/bin/run.sh) script and requires the following:
+[run.sh](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_yarn_client/bin/run.sh)
+script and requires the following:
 
 1. The gateway user (i.e., the user in which Enterprise Gateway is running) must be enabled to perform sudo operations
 on each potential host.  This enablement must also be done to prevent password prompts since Enterprise Gateway runs
@@ -99,6 +106,7 @@ will run as the gateway user **regardless of the value of KERNEL_USERNAME**.
 Jupyter Enterprise Gateway is now configured to perform SSH tunneling on the five ZeroMQ kernel sockets as well as the 
 communication socket created within the launcher and used to perform remote and cross-user signalling functionality.
 
-Should issues arise with respect to SSH tunneling, tunneling can be disabled via the environment variable 
-`EG_ENABLE_TUNNELING=False`.  Note, there is no command-line or configuration file support for this variable.
+Note that SSH tunneling is enabled by default. In order to troubleshoot related issues, tunneling can be disabled via
+the environment variable `EG_ENABLE_TUNNELING=False`.  Note, there is no command-line or configuration file support
+for this variable.
 

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -34,7 +34,7 @@ default_kernel_launch_timeout = float(os.getenv('EG_KERNEL_LAUNCH_TIMEOUT', '30'
 max_poll_attempts = int(os.getenv('EG_MAX_POLL_ATTEMPTS', '10'))
 poll_interval = float(os.getenv('EG_POLL_INTERVAL', '0.5'))
 socket_timeout = float(os.getenv('EG_SOCKET_TIMEOUT', '5.0'))
-tunneling_enabled = bool(os.getenv('EG_ENABLE_TUNNELING', 'False').lower() == 'True'.lower())
+tunneling_enabled = bool(os.getenv('EG_ENABLE_TUNNELING', 'True').lower() == 'True'.lower())
 ssh_port = int(os.getenv('EG_SSH_PORT', '22'))
 
 # Number of seconds in 100 years as the max keep-alive interval value.


### PR DESCRIPTION
For enhanced security, the connections between the
Jupyter Enterprise Gateway and the Kernel as well as
the connection between the Enterprise Gateway and the
Kernel Launcher have been made secure by default. The
documentation has been updated as well with details
about how to turn off tunneling for troubleshooting
purposes.

Addresses #234.