### PR TITLE
Fix signal_kernel() to nolonger assume its only used for interrupts

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -156,25 +156,28 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         """
         self.log.debug("RemoteKernelManager.signal_kernel({})".format(signum))
         if self.has_kernel:
-            if signum == signal.SIGINT and self.sigint_value is None:
-                # If we're interrupting the kernel, check if kernelspec's env defines
-                # an alternate interrupt signal.  We'll do this once per interrupted kernel.
-                self.sigint_value = signum # use default
-                alt_sigint = self.kernel_spec.env.get('EG_ALTERNATE_SIGINT')
-                if alt_sigint:
-                    try:
-                        sig_value = getattr(signal, alt_sigint)
-                        if type(sig_value) is int: # Python 2
-                            self.sigint_value = sig_value
-                        else: # Python 3
-                            self.sigint_value = sig_value.value
-                        self.log.debug("Converted EG_ALTERNATE_SIGINT '{}' to value '{}' to use as interrupt signal.".
-                                         format(alt_sigint, self.sigint_value))
-                    except AttributeError:
-                        self.log.warning("Error received when attempting to convert EG_ALTERNATE_SIGINT of "
-                                         "'{}' to a value. Check kernelspec entry for kernel '{}' - using default 'SIGINT'".
-                                         format(alt_sigint, self.kernel_spec.display_name))
-            self.kernel.send_signal(self.sigint_value)
+            if signum == signal.SIGINT:
+                if self.sigint_value is None:
+                    # If we're interrupting the kernel, check if kernelspec's env defines
+                    # an alternate interrupt signal.  We'll do this once per interrupted kernel.
+                    self.sigint_value = signum # use default
+                    alt_sigint = self.kernel_spec.env.get('EG_ALTERNATE_SIGINT')
+                    if alt_sigint:
+                        try:
+                            sig_value = getattr(signal, alt_sigint)
+                            if type(sig_value) is int: # Python 2
+                                self.sigint_value = sig_value
+                            else: # Python 3
+                                self.sigint_value = sig_value.value
+                            self.log.debug("Converted EG_ALTERNATE_SIGINT '{}' to value '{}' to use as interrupt signal.".
+                                             format(alt_sigint, self.sigint_value))
+                        except AttributeError:
+                            self.log.warning("Error received when attempting to convert EG_ALTERNATE_SIGINT of "
+                                             "'{}' to a value. Check kernelspec entry for kernel '{}' - using default 'SIGINT'".
+                                             format(alt_sigint, self.kernel_spec.display_name))
+                self.kernel.send_signal(self.sigint_value)
+            else:
+                self.kernel.send_signal(signum)
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")
 


### PR DESCRIPTION
A recent change to jupyter_client started using the `signal_kernel()` method
on `KernelManager` for signals other than `SIGINT`.  However, the override
method in `RemoteKernelManager` erroneously assumed that was only called for
interrupt scenarios.  As a result, there was a path that allowed an unset
variable to be used as the signal number rather than the value passed in.

This change fixes that scenario and confirms that tests which were previously
failing when jupyter_client 5.2.0 is installed, now succeed.

Fixes #251