### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Gateway's extensible framework.
 
 ## Features
 
-See the [Features page](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/features.html) in the 
+See [Enterprise Gateway Features](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/getting-started.html#enterprise-gateway-features) in the 
 documentation for a list of Jupyter Enterprise Gateway features.
 
 ## Installation


### PR DESCRIPTION
When the online docs were re-worked a while back, the Features page was
removed and the features merged into the Getting Started page.  This
broke the link to the Features page from the README file.