### PR TITLE
Update NB2KG references to reflect recent repo move and release.

### DIFF
--- a/docs/source/docker.md
+++ b/docs/source/docker.md
@@ -45,11 +45,8 @@ the tag for this image will be `:dev`.
 ### elyra/nb2kg
 
 Image [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) is a simple image built 
-on [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/).  Because 
-enterprise gateway relies on recent NB2KG changes, it's 
-[dockerfile](https://github.com/jupyter-incubator/enterprise_gateway/tree/master/etc/docker/nb2kg/Dockerfile)
-pulls directly from the master branch in git and includes the 
-[latest NB2KG code](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg).  The image 
+on [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/) along with the latest
+release of [NB2KG](https://github.com/jupyter-incubator/nb2kg).  The image 
 also sets some of the new variables that pertain to enterprise gateway (e.g., `KG_REQUEST_TIMEOUT`, 
 `KG_HTTP_USER`, `KERNEL_USERNAME`, etc.).
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -113,8 +113,7 @@ We recommend starting Enterprise Gateway as a background task.  As a result, you
 to create a start script to maintain options, file redirection, etc.
 
 The following script starts Enterprise Gateway with `DEBUG` tracing enabled (default is `INFO`) and idle
-kernel culling for any kernels idle for 12 hours where idle check intervals occur every minute.  
-The Enterprise Gateway log can then be monitored via `tail -F enterprise_gateway.log` and it can be 
+kernel culling for any kernels idle for 12 hours where idle check intervals occur every minute.  The Enterprise Gateway log can then be monitored via `tail -F enterprise_gateway.log` and it can be 
 stopped via `kill $(cat enterprise_gateway.pid)`
 
 ```bash
@@ -133,19 +132,14 @@ fi
 
 ### Connecting a Notebook to Enterprise Gateway
 
-[NB2KG](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) is used to connect from a
+[NB2KG](https://github.com/jupyter-incubator/nb2kg) is used to connect a Notebook from a
 local desktop or laptop to the Enterprise Gateway instance on the Spark/YARN cluster. We strongly recommend
-that the latest version of NB2KG be used as our team has provided some security enhancements to enable for [conveying the notebook 
-user](https://github.com/jupyter/kernel_gateway_demos/pull/48) (for configurations when Enterprise Gateway is
-running behind a secured gateway) and allowing for [increased request 
-timeouts](https://github.com/jupyter/kernel_gateway_demos/pull/55) (due to the longer kernel startup times 
-when interacting with the resource manager or distribution operations). Please follow the [developer 
-instructions](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg#develop) to build the
-latest version until a new release is available (at which time we'll update this information and likely
-include instructions for building a docker image).
+that NB2KG [v0.1.0](https://github.com/jupyter-incubator/nb2kg/releases/tag/v0.1.0) be used as our team has 
+provided some security enhancements to enable for conveying the notebook  user (for configurations when 
+Enterprise Gateway is running behind a secured gateway) and allowing for increased request  timeouts (due 
+to the longer kernel startup times when interacting with the resource manager or distribution operations). 
 
-Extending the notebook launch command listed on the [NB2KG 
-repo](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg#run-notebook-server), 
+Extending the notebook launch command listed on the [NB2KG repo](https://github.com/jupyter-incubator/nb2kg#run-notebook-server), 
 one might use the following...
 
 ```bash
@@ -160,8 +154,8 @@ jupyter notebook \
   --NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager
 ```
 
-For your convenience, we have also build a docker image with latest Jupyter Notebook and latest NB2KG which can be launched
-by the command below:
+For your convenience, we have also build a docker image ([elyra/nb2kg](docker.html#elyra-nb2kg)) with 
+latest Jupyter Notebook and NB2KG which can be launched by the command below:
 
 ```bash
 docker run -t --rm \

--- a/etc/docker/nb2kg/Dockerfile
+++ b/etc/docker/nb2kg/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install setuptools --ignore-installed --upgrade
 USER jovyan
 
 # Install Lab and NB2KG. Enable NB2KG extension.  Lab extension is optionally enabled at runtime.
-RUN pip install jupyterlab "git+https://github.com/jupyter/kernel_gateway_demos.git#egg=nb2kg&subdirectory=nb2kg" && \
+RUN pip install jupyterlab nb2kg && \
     jupyter serverextension enable --py nb2kg --sys-prefix
 
 ADD start-nb2kg.sh /usr/local/share/jupyter/

--- a/etc/docker/nb2kg/README.md
+++ b/etc/docker/nb2kg/README.md
@@ -1,4 +1,4 @@
-This image installs the Jupyter server extensions [NB2KG](https://github.com/jupyter/kernel_gateway_demos/tree/master/nb2kg) 
+This image installs the Jupyter server extensions [NB2KG](https://github.com/jupyter-incubator/nb2kg) 
 and [Jupyter Lab](https://github.com/jupyterlab/jupyterlab) 
  on top of image [jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks/tree/master/minimal-notebook).
 
@@ -8,9 +8,7 @@ instances, although running against Jupyter Kernel Gateway instances should be f
 either form of gateway using either `Jupyter Notebook` or `Jupyter Lab`.
 
 It is built using the latest `minimal-notebook` image and includes the `Jupyter Lab` extension that can be optionally 
-invoked.  The hashed-valued tag of the image corresponds to the `NB2KG` commit hash within the 
-[juptyer/kernel_gateway_demos/nb2kg](https://github.com/jupyter/kernel_gateway_demos/nb2kg) repo that is included 
-in the image.
+invoked.  The tag of the image corresponds to the `NB2KG` release that is included in the image.
 
 
 # Basic Use


### PR DESCRIPTION
NB2KG has recently been promoted from _demo_ to _incubator_ status and published
an official release in PyPi.  As a result, these changes reflect the new repo
location and installation steps (simplified to `pip install nb2kg`).  In additon,
the `elyra/nb2kg` docker image has been updated in docker hub to account for the
official release designation.

Fixes #254