### PR TITLE
Updated YARN cluster mode kernelspecs to use new spark conf parameter

### DIFF
--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -6,8 +6,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d",
-    "SPARK_YARN_USER_ENV": "PATH=/opt/anaconda2/bin:$PATH",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -8,8 +8,7 @@
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip",
-    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip,PATH=/opt/anaconda2/bin:$PATH",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.appMasterEnv.PYTHONUSERBASE=/home/yarn/.local --conf spark.yarn.appMasterEnv.PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.4-src.zip --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -6,8 +6,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_YARN_USER_ENV": "TOREE_ALTERNATE_SIGINT=USR2",
-    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d",
+    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.TOREE_ALTERNATE_SIGINT=USR2",
     "__TOREE_OPTS__": "",
     "TOREE_ALTERNATE_SIGINT": "USR2",
     "EG_ALTERNATE_SIGINT": "SIGUSR2",


### PR DESCRIPTION
Spark 2.2 no longer supports SPARK_YARN_USER_ENV. This removes that deprecated ENV var in the R kernelspec and instead passes in the Yarn env via an extra --conf parameter in spark-submit. 