### PR TITLE
Add support for specifying port range to use for kernel and EG ports

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -186,6 +186,13 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.port=<Integer>
     Default: 8888
     Port on which to listen (KG_PORT env var)
+--EnterpriseGatewayApp.port_range=<Unicode>
+    Default: '0..0'
+    Specifies the lower and upper port numbers from which ports are created.
+    The bounded values are separated by '..' (e.g., 33245..34245 specifies a
+    range of 1000 ports to be randomly selected). A range of zero (e.g.,
+    33245..33245 or 0..0) disables port-range enforcement.  (EG_PORT_RANGE env
+    var)
 --EnterpriseGatewayApp.port_retries=<Integer>
     Default: 50
     Number of ports to try if the specified port is not available
@@ -262,6 +269,17 @@ JupyterWebsocketPersonality options
       startup attempt will take place.  If a second timeout occurs, Enterprise 
       Gateway will report a failure to the client.  
       
+  EG_MAX_PORT_RANGE_RETRIES=5
+      The number of attempts made to locate an available port within the specified 
+      port range.  Only applies when --EnterpriseGatewayApp.port_range 
+      (or EG_PORT_RANGE) has been specified or is in use for the given kernel.
+            
+  EG_MIN_PORT_RANGE_SIZE=1000
+      The minimum port range size permitted when --EnterpriseGatewayApp.port_range 
+      (or EG_PORT_RANGE) is specified or is in use for the given kernel.  Port ranges 
+      reflecting smaller sizes will result in a failure to launch the corresponding 
+      kernel (since port-range can be specified within individual kernel specifications).
+      
   EG_SSH_PORT=22
       The port number used for ssh operations for installations choosing to 
       configure the ssh server on a port other than the default 22.
@@ -315,3 +333,6 @@ but then restrict access at the kernel level.
 globally defined values.  As a result, once a user is denied access at the global level, they will _always be denied
 access at the kernel level_.  These values apply to **all** process-proxy kernels, including the default
 `LocalProcessProxy`.
+* `port_range`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.port_range`.
+Any values specified in the config dictionary override the globally defined values.  These apply to all
+`RemoteProcessProxy` kernels.

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -154,8 +154,8 @@ jupyter notebook \
   --NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager
 ```
 
-For your convenience, we have also build a docker image ([elyra/nb2kg](docker.html#elyra-nb2kg)) with 
-latest Jupyter Notebook and NB2KG which can be launched by the command below:
+For your convenience, we have also built a docker image ([elyra/nb2kg](docker.html#elyra-nb2kg)) with 
+Jupyter Notebook, Jupyter Lab and NB2KG which can be launched by the command below:
 
 ```bash
 docker run -t --rm \
@@ -171,3 +171,4 @@ docker run -t --rm \
   -w /tmp/notebooks \
   elyra/nb2kg
 ```
+To invoke Jupyter Lab, simply add `lab` as the last option following the image name (e.g., `elyra/nb2kg lab`).

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ the number of active kernels can be dramatically increased.
 
    config-options
    troubleshooting
+   debug
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/use-cases.md
+++ b/docs/source/use-cases.md
@@ -14,6 +14,8 @@ other and user can preserve and leverage their own environment, i.e. libraries a
 on my own laptop and leverage my company's large YARN cluster to run my compute-intensive jobs.
 
 - **As a solution architect**, I want to explore supporting a different resource manager with Enterprise Gateway,
-e.g. Kubernetes, by extending and implementing a new ProcessProxy class, e.g. K8ProcessProxy, such that I can easily
+e.g. Kubernetes, by extending and implementing a new ProcessProxy class such that I can easily
 take advantage of specific functionality provided by the resource manager.
 
+- **As an administrator**, I want to constrain applications to specific port ranges so I can more easily identify
+issues and manage network configurations that adhere to my corporate policy.

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-from traitlets import default, List, Set, Unicode, Type, Instance, Bool
+from traitlets import default, List, Set, Unicode, Type, Instance, Bool, Integer
 
 from kernel_gateway.gatewayapp import KernelGatewayApp
 
@@ -113,6 +113,18 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     def authorized_users_default(self):
         au_env = os.getenv(self.authorized_users_env)
         return au_env.split(',') if au_env is not None else []
+
+    # Port range
+    port_range_env = 'EG_PORT_RANGE'
+    port_range_default_value = "0..0"
+    port_range = Unicode(port_range_default_value, config=True,
+        help="""Specifies the lower and upper port numbers from which ports are created.  The bounded values
+        are separated by '..' (e.g., 33245..34245 specifies a range of 1000 ports to be randomly selected).
+        A range of zero (e.g., 33245..33245 or 0..0) disables port-range enforcement.  (EG_PORT_RANGE env var)""")
+
+    @default('port_range')
+    def port_range_default(self):
+        return os.getenv(self.port_range_env, self.port_range_default_value)
 
     kernel_spec_manager = Instance(RemoteKernelSpecManager, allow_none=True)
 

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -194,4 +194,11 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         # If this is a remote kernel that's using a response address, we should skip the write_connection_file
         # since it will create 5 useless ports that would not adhere to port-range restrictions if configured.
         if not isinstance(self.process_proxy, RemoteProcessProxy) or not self.response_address:
+            # However, since we *may* want to limit the selected ports, go ahead and get the ports using
+            # the process proxy (will be LocalPropcessProxy for default case) since the port selection will
+            # handle the default case when the member ports aren't set anyway.
+            ports = self.process_proxy.select_ports(5)
+            self.shell_port=ports[0]; self.iopub_port=ports[1]; self.stdin_port=ports[2]; \
+                self.hb_port=ports[3]; self.control_port=ports[4]
+
             return super(RemoteKernelManager, self).write_connection_file()

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -99,12 +99,15 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         return super(RemoteKernelManager, self).start_kernel(**kw)
 
     def format_kernel_cmd(self, extra_arguments=None):
-        """replace templated args (e.g. {response_address})"""
+        """replace templated args (e.g. {response_address} or {port_range})"""
         cmd = super(RemoteKernelManager, self).format_kernel_cmd(extra_arguments)
 
-        if self.response_address:
-            ns = dict(response_address=self.response_address,)
-            ns.update(self._launch_args)
+        if self.response_address or self.port_range:
+            ns = self._launch_args.copy()
+            if self.response_address:
+                ns['response_address'] = self.response_address
+            if self.port_range:
+                ns['port_range'] = self.port_range
 
             pat = re.compile(r'\{([A-Za-z0-9_]+)\}')
             def from_ns(match):
@@ -187,8 +190,7 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         return super(RemoteKernelManager, self).load_connection_info(info)
 
     def write_connection_file(self):
-        # Override purely for debug purposes
-        self.log.debug(
-            "RemoteKernelManager: Writing connection file with ip={}, control={}, hb={}, iopub={}, stdin={}, shell={}"
-            .format(self.ip, self.control_port, self.hb_port, self.iopub_port, self.stdin_port, self.shell_port))
-        return super(RemoteKernelManager, self).write_connection_file()
+        # If this is a remote kernel that's using a response address, we should skip the write_connection_file
+        # since it will create 5 useless ports that would not adhere to port-range restrictions if configured.
+        if not isinstance(self.process_proxy, RemoteProcessProxy) or not self.response_address:
+            return super(RemoteKernelManager, self).write_connection_file()

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -88,6 +88,7 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
     process_proxy = None
     response_address = None
     sigint_value = None
+    port_range = None
 
     def start_kernel(self, **kw):
         if self.kernel_spec.process_proxy_class:

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -398,6 +398,10 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         self._prepare_response_socket()
 
     def launch_process(self, kernel_cmd, **kw):
+        # Pass along port-range info to kernels...
+        kw['env']['EG_MIN_PORT_RANGE_SIZE'] = min_port_range_size
+        kw['env']['EG_MAX_PORT_RANGE_RETRIES'] = max_port_range_retries
+
         super(RemoteProcessProxy, self).launch_process(kernel_cmd, **kw)
         # remove connection file because a) its not necessary any longer since launchers will return
         # the connection information which will (sufficiently) remain in memory and b) launchers

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -399,8 +399,8 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
 
     def launch_process(self, kernel_cmd, **kw):
         # Pass along port-range info to kernels...
-        kw['env']['EG_MIN_PORT_RANGE_SIZE'] = min_port_range_size
-        kw['env']['EG_MAX_PORT_RANGE_RETRIES'] = max_port_range_retries
+        kw['env']['EG_MIN_PORT_RANGE_SIZE'] = str(min_port_range_size)
+        kw['env']['EG_MAX_PORT_RANGE_RETRIES'] = str(max_port_range_retries)
 
         super(RemoteProcessProxy, self).launch_process(kernel_cmd, **kw)
         # remove connection file because a) its not necessary any longer since launchers will return
@@ -554,6 +554,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         """Create and return a socket whose port is available and adheres to the given port range, if applicable."""
         sock = socket(AF_INET, SOCK_STREAM)
         found_port = False
+        retries = 0
         while not found_port:
             try:
                 sock.bind((ip, self._get_candidate_port()))

--- a/etc/kernel-launchers/R/scripts/gateway_listener.py
+++ b/etc/kernel-launchers/R/scripts/gateway_listener.py
@@ -3,18 +3,60 @@ import tempfile
 import json
 import uuid
 import signal
+import random
 from socket import *
 from ipython_genutils.py3compat import str_to_bytes
 from jupyter_client.connect import write_connection_file
 from threading import Thread
 
-def prepare_gateway_socket():
+max_port_range_retries = int(os.getenv('EG_MAX_PORT_RANGE_RETRIES', '5'))
+
+
+def _select_ports(count, lower_port, upper_port):
+    """Select and return n random ports that are available and adhere to the given port range, if applicable."""
+    ports = []
+    sockets = []
+    for i in range(count):
+        sock = _select_socket(lower_port, upper_port)
+        ports.append(sock.getsockname()[1])
+        sockets.append(sock)
+    for sock in sockets:
+        sock.close()
+    return ports
+
+
+def _select_socket(lower_port, upper_port):
+    """Create and return a socket whose port is available and adheres to the given port range, if applicable."""
     sock = socket(AF_INET, SOCK_STREAM)
-    sock.bind(('0.0.0.0', 0))
+    found_port = False
+    retries = 0
+    while not found_port:
+        try:
+            sock.bind(('0.0.0.0', _get_candidate_port(lower_port, upper_port)))
+            found_port = True
+        except Exception as e:
+            retries = retries + 1
+            if retries > max_port_range_retries:
+                raise RuntimeError(
+                    "Failed to locate port within range {}..{} after {} retries!".
+                    format(lower_port, upper_port, max_port_range_retries))
+    return sock
+
+
+def _get_candidate_port(lower_port, upper_port):
+    range_size = upper_port - lower_port
+    if range_size == 0:
+        return 0
+    return random.randint(lower_port, upper_port)
+
+
+def prepare_gateway_socket(lower_port, upper_port):
+    sock = _select_socket(lower_port, upper_port)
     print("Signal socket bound to host: {}, port: {}".format(sock.getsockname()[0], sock.getsockname()[1]))
     sock.listen(1)
     sock.settimeout(5)
     return sock
+
 
 def get_gateway_request(sock):
     conn = None
@@ -64,26 +106,29 @@ def gateway_listener(sock, parent_pid):
                 print("Listener detected parent has been shutdown.")
 
 
-def setup_gateway_listener(fname, parent_pid):
+def setup_gateway_listener(fname, parent_pid, lower_port, upper_port):
     ip = "0.0.0.0"
     key = str_to_bytes(str(uuid.uuid4()))
 
-    gateway_socket = prepare_gateway_socket()
+    gateway_socket = prepare_gateway_socket(lower_port, upper_port)
 
     gateway_listener_thread = Thread(target=gateway_listener, args=(gateway_socket,parent_pid,))
     gateway_listener_thread.start()
 
-    prev_connection_file = fname
     basename = os.path.splitext(os.path.basename(fname))[0]
     fd, conn_file = tempfile.mkstemp(suffix=".json", prefix=basename + "_")
     os.close(fd)
-    conn_file, config = write_connection_file(conn_file, ip=ip, key=key)
+
+    ports = _select_ports(5, lower_port, upper_port)
+
+    conn_file, config = write_connection_file(fname=conn_file, ip=ip, key=key, shell_port=ports[0], iopub_port=ports[1],
+                          stdin_port=ports[2], hb_port=ports[3], control_port=ports[4])
     try:
         os.remove(conn_file)
     except:
         pass
 
-	# Add in the gateway_socket and parent_pid fields...
+    # Add in the gateway_socket and parent_pid fields...
     config['comm_port'] = gateway_socket.getsockname()[1]
     config['pid'] = parent_pid
     

--- a/etc/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/etc/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -166,7 +166,7 @@ validate_port_range <- function(port_range){
 
 # Check arguments
 parser <- arg_parser('R-kernel-launcher')
-parser <- add_argument(parser, "--port-range",
+parser <- add_argument(parser, "--RemoteProcessProxy.port-range",
        help="the range of ports impose for kernel ports")
 parser <- add_argument(parser, "--RemoteProcessProxy.response-address",
        help="the IP:port address of the system hosting JKG and expecting response")
@@ -184,8 +184,8 @@ if (!file.exists(connection_file)){
     # if port-range was provided, validate the range and determine bounds
     lower_port = 0
     upper_port = 0
-    if (!is.na(argv$port_range)){
-        range <- validate_port_range(argv$port_range)
+    if (!is.na(argv$RemoteProcessProxy.port_range)){
+        range <- validate_port_range(argv$RemoteProcessProxy.port_range)
         if (!is.na(range)){
             lower_port = range$lower_port
             upper_port = range$upper_port

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -204,6 +204,9 @@ def _get_candidate_port(lower_port, upper_port):
 
 
 def _validate_port_range(port_range):
+    # if no argument was provided, return a range of 0
+    if not port_range:
+        return 0, 0
     try:
         port_ranges = port_range.split("..")
         lower_port = int(port_ranges[0])

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
     parser.add_argument('--RemoteProcessProxy.disable-gateway-socket', dest='disable_gateway_socket',
                         action='store_true', help='Disable use of gateway socket for extended communications',
                         default=False)
-    parser.add_argument('--port-range', dest='port_range',
+    parser.add_argument('--RemoteProcessProxy.port-range', dest='port_range',
                         metavar='<lowerPort>..<upperPort>', help='Port range to impose for kernel ports')
 
     arguments = vars(parser.parse_args())

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -182,6 +182,7 @@ def _select_socket(lower_port, upper_port):
     """Create and return a socket whose port is available and adheres to the given port range, if applicable."""
     sock = socket(AF_INET, SOCK_STREAM)
     found_port = False
+    retries = 0
     while not found_port:
         try:
             sock.bind(('0.0.0.0', _get_candidate_port(lower_port, upper_port)))

--- a/etc/kernel-launchers/scala/toree-launcher/build.sbt
+++ b/etc/kernel-launchers/scala/toree-launcher/build.sbt
@@ -2,6 +2,7 @@
  * Copyright (c) Jupyter Development Team.
  * Distributed under the terms of the Modified BSD License.
  */
+
 name := "toree-launcher"
 
 version := sys.props.getOrElse("version", default = "1.0").replaceAll("dev[0-9]", "SNAPSHOT")

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
@@ -5,49 +5,53 @@
 
 package launcher
 
-import java.net.ServerSocket
+
 import java.util.UUID.randomUUID
 import play.api.libs.json._
+import scala.util.Random
+import launcher.utils.SocketUtils
 
 
-case class KernelProfile(hb_port : Int, control_port : Int,
-                         iopub_port : Int, stdin_port : Int,
-                         shell_port : Int, key : String,
-                         kernel_name : String, signature_scheme : String,
-                         transport : String, ip : String)
+case class KernelProfile(hb_port : Int,
+                         control_port : Int,
+                         iopub_port : Int,
+                         stdin_port : Int,
+                         shell_port : Int,
+                         key : String,
+                         kernel_name : String,
+                         signature_scheme : String,
+                         transport : String,
+                         ip : String)
 
-object KernelProfile{
+object KernelProfile {
 
-  def getFivePort() : Array[Int] = {
-    val total = 5
-    val portArray = new Array[Int](total)
-    val socketArray = new Array[ServerSocket](total)
+  def getUnusedPort(hasPortRange: Boolean = false,
+                  portLowerBound: Int = -1,
+                  portUpperBound: Int = -1) : Int = {
 
-    for(i <- 0 until total){
-      socketArray(i) = new ServerSocket(0)
-      portArray(i) = socketArray(i).getLocalPort
+    if (hasPortRange) {
+      return SocketUtils.findPortInRange(portLowerBound, portUpperBound)
+    } else {
+      return SocketUtils.findRandomPort
     }
-    // Now close all sockets
-    for(i <- 0 until total){
-      val temp = socketArray(i).getLocalPort
-      socketArray(i).close()
-      println("Port %s closed...".format(temp))
-    }
-    portArray
   }
 
 
   def newKey() : String = randomUUID.toString
 
-  def createJsonProfile() : String = {
+  def createJsonProfile(hasPortRange: Boolean = false,
+                        portLowerBound: Int = -1,
+                        portUpperBound: Int = -1) : String = {
 
     implicit val writes = Json.writes[KernelProfile]
 
-    val fivePorts = getFivePort()
-
     val newKernelProfile = new KernelProfile(
-      hb_port = fivePorts(0), control_port = fivePorts(1), iopub_port = fivePorts(2),
-      stdin_port = fivePorts(3), shell_port = fivePorts(4), key = newKey(),
+      hb_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      control_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      iopub_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      stdin_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      shell_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      key = newKey(),
       kernel_name = "Apache Toree Scala", transport = "tcp", ip = "0.0.0.0",
       signature_scheme = "hmac-sha256"
     )

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/KernelProfile.scala
@@ -25,32 +25,19 @@ case class KernelProfile(hb_port : Int,
 
 object KernelProfile {
 
-  def getUnusedPort(hasPortRange: Boolean = false,
-                  portLowerBound: Int = -1,
-                  portUpperBound: Int = -1) : Int = {
-
-    if (hasPortRange) {
-      return SocketUtils.findPortInRange(portLowerBound, portUpperBound)
-    } else {
-      return SocketUtils.findRandomPort
-    }
-  }
-
-
   def newKey() : String = randomUUID.toString
 
-  def createJsonProfile(hasPortRange: Boolean = false,
-                        portLowerBound: Int = -1,
+  def createJsonProfile(portLowerBound: Int = -1,
                         portUpperBound: Int = -1) : String = {
 
     implicit val writes = Json.writes[KernelProfile]
 
     val newKernelProfile = new KernelProfile(
-      hb_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
-      control_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
-      iopub_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
-      stdin_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
-      shell_port = getUnusedPort(hasPortRange, portLowerBound, portUpperBound),
+      hb_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      control_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      iopub_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      stdin_port = SocketUtils.findPort(portLowerBound, portUpperBound),
+      shell_port = SocketUtils.findPort(portLowerBound, portUpperBound),
       key = newKey(),
       kernel_name = "Apache Toree Scala", transport = "tcp", ip = "0.0.0.0",
       signature_scheme = "hmac-sha256"

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
@@ -70,7 +70,7 @@ object ToreeLauncher {
 
     args.sliding(2, 1).toList.collect {
       case Array("--profile", arg: String) => profilePath = arg.trim
-      case Array("--port-range", arg: String) => initPortRange(arg.trim)
+      case Array("--RemoteProcessProxy.port-range", arg: String) => initPortRange(arg.trim)
       case Array("--RemoteProcessProxy.response-address", arg: String) => responseAddress = arg.trim
       case Array("--RemoteProcessProxy.disable-gateway-socket", arg: String) =>
             disableGatewaySocket = arg.trim.toBoolean

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SecurityUtils.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SecurityUtils.scala
@@ -1,0 +1,58 @@
+/**
+  * Copyright (c) Jupyter Development Team.
+  * Distributed under the terms of the Modified BSD License.
+  */
+
+package launcher.utils
+
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import java.util.Base64
+
+import javax.crypto.Cipher
+import javax.crypto.spec.SecretKeySpec
+
+object SecurityUtils {
+
+  def encrypt(profilePath: String, value: String): String = {
+    if (profilePath.indexOf("kernel-") == -1) {
+      println("Invalid connection file name '%s', now exit.".format(profilePath)) // scalastyle:off
+      sys.exit(-1)
+    }
+
+    val clearText = getClearText(value)
+    val cipher: Cipher = Cipher.getInstance("AES")
+    val file = new java.io.File(profilePath)
+    val fileName = file.getName()
+    val tokens = fileName.split("kernel-")
+    val key = tokens(1).substring(0, 16)
+    val aesKey: Key = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES")
+
+    println("Raw Payload: '%s'".format(clearText))
+    // println("AES Key: '%s'".format(key))
+    cipher.init(Cipher.ENCRYPT_MODE, aesKey)
+    Base64.getEncoder.encodeToString(cipher.doFinal(clearText.getBytes(StandardCharsets.UTF_8)))
+  }
+
+  private def getClearText(value: String): String = {
+    val len = value.length()
+
+    if (len % 16 == 0) {
+      // If the length of the string is already a multiple of 16, then
+      // just return it.
+      value
+    }
+    else {
+      // Ensure that the length of the data that will be encrypted is a
+      // multiple of 16 by padding with '%' on the right.
+      //
+      // Note that the padding is not needed in Scala but Python and R
+      // need padding. In order to keep things consistent across all the
+      // languages(so that EG on the receiving end can behave the same
+      // way regardless of the language), we are also padding for Scala.
+      val targetLength = (len / 16 + 1) * 16
+      val clearText = value.padTo(targetLength, "%").mkString
+      clearText
+    }
+  }
+}

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SocketUtils.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/utils/SocketUtils.scala
@@ -1,0 +1,91 @@
+/**
+  * Copyright (c) Jupyter Development Team.
+  * Distributed under the terms of the Modified BSD License.
+  */
+
+package launcher.utils
+
+import java.io.PrintStream
+import java.net.{InetAddress, ServerSocket, Socket}
+
+import scala.util.Random
+
+
+object SocketUtils {
+  val PORT_DEFAULT_LOWER_BOUND: Int = 1024
+  val PORT_DEFAULT_UPPER_BOUND: Int = 65535
+  val random: Random = new Random (System.currentTimeMillis)
+
+  def writeToSocket(socketAddress : String, content : String): Unit = {
+    val ipPort = socketAddress.split(":")
+    if (ipPort.length == 2) {
+      println("Sending connection info to gateway at %s\n%s".format(socketAddress, content)) // scalastyle:off
+      val ip = ipPort(0)
+      val port = ipPort(1).toInt
+      val s = new Socket(InetAddress.getByName(ip), port)
+      val out = new PrintStream(s.getOutputStream)
+      try {
+        out.append(content)
+        out.flush()
+      } finally {
+        s.close()
+      }
+    } else {
+      println("Invalid format for response address '%s'!".format(socketAddress)) // scalastyle:off
+    }
+  }
+
+  def findRandomPort(): Int = {
+    val socket = new ServerSocket(0)
+    val port = socket.getLocalPort
+
+    // now Close the port
+    socket.close()
+    println("Port %s closed...".format(port)) // scalastyle:off
+
+    return port
+  }
+
+  def findPortInRange(portLowerBound: Int = PORT_DEFAULT_LOWER_BOUND,
+                      portUpperBound: Int = PORT_DEFAULT_UPPER_BOUND): Int = {
+
+    var foundAvailable: Boolean = false
+    var port = -1
+
+    while (foundAvailable == false) {
+
+      val randomPort = getRandomPortInRange(portLowerBound, portUpperBound)
+
+      try {
+
+        // try a randomPort
+        println("Trying port %s ...".format(randomPort)) // scalastyle:off
+        val socket = new ServerSocket(randomPort)
+        println("port %s is available".format(randomPort)) // scalastyle:off
+
+        // now Close the port
+        socket.close()
+        println("Port %s closed...".format(randomPort)) // scalastyle:off
+
+        // return the port to be used
+        port = randomPort
+        foundAvailable = true
+
+      } catch {
+        case _ : Throwable => println("port %s is in use".format(randomPort)) // scalastyle:off
+      }
+    }
+
+    return port
+  }
+
+  private def getRandomPortInRange(portLowerBound: Int = PORT_DEFAULT_LOWER_BOUND,
+                                   portUpperBound: Int = PORT_DEFAULT_UPPER_BOUND): Int = {
+
+    val portRange = portUpperBound - portLowerBound
+    val randomPort = random.nextInt(portRange)
+    val port = portLowerBound + randomPort
+
+    return port
+  }
+}


### PR DESCRIPTION
Add --kernel-port-range parameter that takes a range of
ports on the format xxx..yyy where xxx is the lower bound
port number and yyy is the upper bound port number and when
choosing the ports to use, the kernel launcher will consider
those boundaries to select the port

Fixes #288