### PR TITLE
Use UTF-8 encoding while encrypting and decrypting

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -510,7 +510,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         # self.log.debug("AES Decryption Key '{}'".format(key))
         cipher = AES.new(key)
         payload = decryptAES(cipher, data)
-        payload = "".join([payload.rsplit("}", 1)[0], "}"])  # Get rid of padding after the '}'.
+        payload = "".join([payload.decode("utf-8").rsplit("}", 1)[0], "}"])  # Get rid of padding after the '}'.
         return payload
 
     def receive_connection_info(self):

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -83,7 +83,7 @@ def _encrypt(connection_info, conn_file):
     # Ensure that the length of the data that will be encrypted is a
     # multiple of BLOCK_SIZE by padding with '%' on the right.
     PADDING = '%'
-    pad = lambda s: s + (BLOCK_SIZE - len(s) % BLOCK_SIZE) * PADDING
+    pad = lambda s: s.decode("utf-8") + (BLOCK_SIZE - len(s) % BLOCK_SIZE) * PADDING
 
     # Encrypt connection_info whose length is a multiple of BLOCK_SIZE using
     # AES cipher and then encode the resulting byte array using Base64.


### PR DESCRIPTION
This makes the encrypting and decrypting process compatible
with Python 3.6 especially when the Kernel and the EG are
running in different environments.

Fixes #271.