### PR TITLE
Patch release

### DIFF
--- a/etc/docker/yarn-spark/Dockerfile
+++ b/etc/docker/yarn-spark/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /tmp && \
 	curl -LO 'http://vault.centos.org/6.9/os/Source/SPackages/rsyslog-5.8.10-10.el6_6.src.rpm' && \
 	rpm -i /tmp/rsyslog-5.8.10-10.el6_6.src.rpm && \
 	rm -f /tmp/rsyslog-5.8.10-10.el6_6.src.rpm && \
-	RUN cat /etc/bootstrap.sh | sed s/'service sshd'/'service rsyslog start|service sshd'/ | tr '|' '\n' > /tmp/bootstrap.sh && \
+	cat /etc/bootstrap.sh | sed s/'service sshd'/'service rsyslog start|service sshd'/ | tr '|' '\n' > /tmp/bootstrap.sh && \
 	mv /tmp/bootstrap.sh /etc && \
 	chmod 700 /etc/bootstrap.sh
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ Jupyter Notebooks to share resources across an Apache Spark cluster.
         'scripts/jupyter-enterprisegateway'
     ],
     install_requires=[
-        'jupyter_core>=4.0',
+        'jupyter_core>=4.4.0',
         'jupyter_client>=4.2.0',
         'notebook>=5.1.0,<6.0',
         'jupyter_kernel_gateway>=1.1.2',


### PR DESCRIPTION
In the course of building the enterprise-gateway docker image for the 0.8.0 release, some issues were discovered - one minor, the other a bit worse.
1. There was an issue with the yarn-spark Dockerfile that prevented a portion of the build to not work correctly.  Since this is a dependent image, its probably not critical, but needs to be fixed.
2. The dependency on jupyter-core >= `4.4.0` was missing from setup.py (although present in requirements.txt files).  This results in a failure when starting enterprise gateway because the `4.3.0` version remains in the image.  The failure consists of the following traceback:
```
  File "/opt/anaconda2/lib/python2.7/site-packages/kernel_gateway/__init__.py", line 4, in <module>
    from .gatewayapp import launch_instance
  File "/opt/anaconda2/lib/python2.7/site-packages/kernel_gateway/gatewayapp.py", line 13, in <module>
    from notebook.services.kernels.kernelmanager import MappingKernelManager
  File "/opt/anaconda2/lib/python2.7/site-packages/notebook/__init__.py", line 25, in <module>
    from .nbextensions import install_nbextension
  File "/opt/anaconda2/lib/python2.7/site-packages/notebook/nbextensions.py", line 27, in <module>
    from jupyter_core.utils import ensure_dir_exists
ImportError: cannot import name ensure_dir_exists
```
By reflecting the correct dependency in `setup.py` jupyter-core will be appropriately upgraded to `4.4.0`.