### PR TITLE
RFC 793 compliance for port range

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -191,8 +191,9 @@ EnterpriseGatewayApp options
     Specifies the lower and upper port numbers from which ports are created.
     The bounded values are separated by '..' (e.g., 33245..34245 specifies a
     range of 1000 ports to be randomly selected). A range of zero (e.g.,
-    33245..33245 or 0..0) disables port-range enforcement.  (EG_PORT_RANGE env
-    var)
+    33245..33245 or 0..0) disables port-range enforcement. If the specified
+    range overlaps with TCP's well-known port range of (0, 1024], then a
+    RuntimeError will be thrown. (EG_PORT_RANGE env var)
 --EnterpriseGatewayApp.port_retries=<Integer>
     Default: 50
     Number of ports to try if the specified port is not available

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -157,3 +157,25 @@ but it failed with a "Kernel error" and a SSHException.**
    This is usually seen when you are trying to use more resources then what is available for your kernel.
    To address this issue, increase the amount of memory available for your YARN application or another
    Resource Manager managing the kernel.
+
+- **I'm trying to launch a (Python/Scala/R) kernel with port range but it failed with `RuntimeError: Invalid port range `.**
+
+    ```
+    Traceback (most recent call last):
+      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/web.py", line 1511, in _execute
+        result = yield result
+      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/gen.py", line 1055, in run
+        value = future.result()
+      ....
+      ....
+      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 478, in __init__
+        super(RemoteProcessProxy, self).__init__(kernel_manager, proxy_config)
+      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 87, in __init__
+        self._validate_port_range(proxy_config)
+      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 407, in _validate_port_range
+        "port numbers is (1024, 65535).".format(self.lower_port))
+    RuntimeError: Invalid port range '1000..2000' specified. Range for valid port numbers is (1024, 65535).
+    ```
+
+    To address this issue, make sure that the specified port range does not overlap with TCP's well-known
+    port range of (0, 1024].

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -14,6 +14,8 @@
     "/usr/local/share/jupyter/kernels/spark_R_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -13,6 +13,8 @@
     "/usr/local/share/jupyter/kernels/spark_R_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -11,6 +11,8 @@
   "argv": [ 
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -16,6 +16,8 @@
     "/usr/local/share/jupyter/kernels/spark_python_yarn_client/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -15,6 +15,8 @@
     "/usr/local/share/jupyter/kernels/spark_python_yarn_cluster/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_scala_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_client/kernel.json
@@ -16,6 +16,8 @@
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -16,6 +16,8 @@
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}"
   ]
 }


### PR DESCRIPTION
Since port number is a 16-bit unsigned int, it must be in
the range (0, 65535). However, TCP also sets aside ports in
the range (0, 1024] as well-known ports that are reserved
for specific purposes. This change set adds checks to ensure
that specified port range falls within (1024, 65535). Updated
all the `kernel.json` files by adding the argument
`--RemoteProcessProxy.port-range`. Updated the configuration
and troubleshooting documentation.

Addresses: Issue #290