### PR TITLE
Fix test issue with tornado 5.x and update setup.py

### DIFF
--- a/enterprise_gateway/tests/test_notebook_http.py
+++ b/enterprise_gateway/tests/test_notebook_http.py
@@ -5,6 +5,7 @@
 import os
 import sys
 import json
+import tornado
 
 from .test_gatewayapp import TestGatewayAppBase, RESOURCES
 from kernel_gateway.notebook_http.swagger.handlers import SwaggerSpecHandler
@@ -381,13 +382,19 @@ class TestKernelPool(TestGatewayAppBase):
             method='GET',
             raise_error=False
         )
-        self.assertTrue(response_long_running.running(), 'Long HTTP Request is not running')
+        if tornado.version.startswith("4"):
+            self.assertTrue(response_long_running.running(), 'Long HTTP Request is not running')
+        else:
+            self.assertFalse(response_long_running.done(), 'Long HTTP Request is not running')
         response_short_running = yield self.http_client.fetch(
             self.get_url('/sleep/3'),
             method='GET',
             raise_error=False
         )
-        self.assertTrue(response_long_running.running(), 'Long HTTP Request is not running')
+        if tornado.version.startswith("4"):
+            self.assertTrue(response_long_running.running(), 'Long HTTP Request is not running')
+        else:
+            self.assertFalse(response_long_running.done(), 'Long HTTP Request is not running')
         self.assertEqual(response_short_running.code, 200, 'Short HTTP Request did not return proper status code of 200')
 
     @gen_test

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,15 @@ Jupyter Notebooks to share resources across an Apache Spark cluster.
     ],
     install_requires=[
         'jupyter_core>=4.4.0',
-        'jupyter_client>=4.2.0',
-        'notebook>=5.1.0,<6.0',
-        'jupyter_kernel_gateway>=1.1.2',
+        'jupyter_client>=5.2.0',
+        'notebook>=5.3.0,<6.0',
+        'jupyter_kernel_gateway>=2.0.0',
         'traitlets>=4.2.0',
-        'tornado>=4.2.0,<5.0',
+        'tornado>=4.2.0',
         'requests>=2.7,<3.0',
         'paramiko>=2.1.2',
-        'yarn-api-client>=0.2.3'
+        'yarn-api-client>=0.2.3',
+        'pyzmq>=17.0.0'
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Continuation of Issue-278
- Updated setup.py with dependency changes
- Applied fix for tornado test failure (TEST: Concurrent requests should not be blocked) thx luciano

Tests pass however, seeing some post test errors related to the tornado changes when python environment is 3.4+

WIP
