### PR TITLE
Add support for enforcing the maximum number of kernels a user can ha…

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -183,6 +183,11 @@ EnterpriseGatewayApp options
     Default: None
     Limits the number of kernel instances allowed to run by this gateway.
     Unbounded by default. (KG_MAX_KERNELS env var)
+--EnterpriseGatewayApp.max_kernels_per_user=<Integer>
+    Default: -1
+    Specifies the maximum number of kernels a user can have active
+    simultaneously.  A value of -1 disables enforcement.
+    (EG_MAX_KERNELS_PER_USER env var)
 --EnterpriseGatewayApp.port=<Integer>
     Default: 8888
     Port on which to listen (KG_PORT env var)

--- a/docs/source/use-cases.md
+++ b/docs/source/use-cases.md
@@ -19,3 +19,6 @@ take advantage of specific functionality provided by the resource manager.
 
 - **As an administrator**, I want to constrain applications to specific port ranges so I can more easily identify
 issues and manage network configurations that adhere to my corporate policy.
+
+- **As an administrator**, I want to constrain the number of active kernels that each of my users can have at any 
+given time.

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -136,6 +136,17 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     def port_range_default(self):
         return os.getenv(self.port_range_env, self.port_range_default_value)
 
+    # Max Kernels per User
+    max_kernels_per_user_env = 'EG_MAX_KERNELS_PER_USER'
+    max_kernels_per_user_default_value = -1
+    max_kernels_per_user = Integer(max_kernels_per_user_default_value, config=True,
+        help="""Specifies the maximum number of kernels a user can have active simultaneously.  A value of -1 disables
+        enforcement.  (EG_MAX_KERNELS_PER_USER env var)""")
+
+    @default('max_kernels_per_user')
+    def max_kernels_per_user_default(self):
+        return int(os.getenv(self.max_kernels_per_user_env, self.max_kernels_per_user_default_value))
+
     kernel_spec_manager = Instance(RemoteKernelSpecManager, allow_none=True)
 
     kernel_spec_manager_class = Type(


### PR DESCRIPTION
…ve active.

Added option `--EnterpriseGatewayApp.max_kernels_per_user` (env: `EG_MAX_KERNELS_PER_USER`).
Default value is -1 and disables enforcement.  When >= 0, the sessions dictionary is consulted
to determine if the current number of sessions for the given user is less than the imposed
maximum. If the current count is >= the imposed maximum, a 403 will be raised with an
appropraitely logged message.  Otherwise, kernel satartup will proceed and the new session
will be tracked.  Kernel shutdown removes the previously tracked session.

This change enables the in-memory session management logic that had been conditionally
enabled.  The persistence logic is still disabled by default.

Fixes #295