### PR TITLE
Changes necessary to flow custom error messages to client.

### DIFF
--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -121,4 +121,4 @@ class DistributedProcessProxy(RemoteProcessProxy):
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.log.error(timeout_message)
             self.kill()
-            raise tornado.web.HTTPError(error_http_code, timeout_message)
+            raise tornado.web.HTTPError(error_http_code, reason=timeout_message)

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -238,7 +238,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
             if e is paramiko.SSHException or paramiko.AuthenticationException:
                 error_message_prefix = "Failed to authenticate SSHClient with password"
                 error_message = error_message_prefix + (" provided" if remote_pwd else "-less SSH")
-                raise tornado.web.HTTPError(403, error_message)
+                raise tornado.web.HTTPError(403, reason=error_message)
             else:
                 raise e
         return ssh
@@ -351,7 +351,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
                         "Ensure KERNEL_USERNAME is set to an appropriate value and retry the request.". \
             format(kernel_username, differentiator_clause, kernel_clause)
         self.log.error(error_message)
-        raise tornado.web.HTTPError(403, error_message)
+        raise tornado.web.HTTPError(403, reason=error_message)
 
     def get_process_info(self):
         process_info = {'pid': self.pid, 'pgid': self.pgid, 'ip': self.ip}
@@ -666,9 +666,10 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
                 if conn:
                     conn.close()
         else:
-            raise tornado.web.HTTPError(500,
-                                        "Unexpected runtime found for KernelID '{}'!  "
-                                        "No response socket exists".format(self.kernel_id))
+            error_message = "Unexpected runtime found for Kernel ID '{}'!  No response socket exists".format(self.kernel_id)
+            self.log.error(error_message)
+            raise tornado.web.HTTPError(500, reason=error_message)
+
         return ready_to_connect
 
     # Do NOT update connect_info with IP and other such artifacts in this method/function.

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -154,10 +154,11 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                 app_state = self.get_application_state()
 
                 if app_state in YarnClusterProcessProxy.final_states:
-                    raise tornado.web.HTTPError(500, "KernelID: '{}', ApplicationID: '{}' unexpectedly found in"
-                                                     "state '{}' during kernel startup!".format(self.kernel_id,
-                                                                                                self.application_id,
-                                                                                                app_state))
+                    error_message = "KernelID: '{}', ApplicationID: '{}' unexpectedly found in " \
+                                                     "state '{}' during kernel startup!".\
+                                    format(self.kernel_id, self.application_id, app_state)
+                    self.log.error(error_message)
+                    raise tornado.web.HTTPError(500, reason=error_message)
 
                 self.log.debug("{}: State: '{}', Host: '{}', KernelID: '{}', ApplicationID: '{}'".
                                format(i, app_state, self.assigned_host, self.kernel_id, self.application_id))
@@ -199,7 +200,7 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
             self.kill()
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.log.error(timeout_message)
-            raise tornado.web.HTTPError(error_http_code, timeout_message)
+            raise tornado.web.HTTPError(error_http_code, reason=timeout_message)
 
     def get_application_id(self, ignore_final_states=False):
         # Return the kernel's YARN application ID if available, otherwise None.  If we're obtaining application_id


### PR DESCRIPTION
This PR also requires [Kernel Gateway PR 284](https://github.com/jupyter/kernel_gateway/pull/284)

In absence of that PR, the default message corresponding to the status code will
be returned to the caller.  So this PR is essentially preparation to have custom
error messages returned.

Fixes #296