### PR TITLE
Remove code that terminates launcher prematurely

### DIFF
--- a/etc/kernel-launchers/R/scripts/gateway_listener.py
+++ b/etc/kernel-launchers/R/scripts/gateway_listener.py
@@ -95,9 +95,7 @@ def gateway_listener(sock, parent_pid):
                 os.kill(int(parent_pid), signum)
             elif request.get('shutdown'):
                 shutdown = bool(request.get('shutdown'))
-                if shutdown:
-                    print("Listener received shutdown request, terminating parent (pid: {}).".format(parent_pid))
-                    os.kill(int(parent_pid), signal.SIGTERM)
+
         else:  # check parent
             try:
                 os.kill(int(parent_pid), 0)


### PR DESCRIPTION
The launcher was terminating itself on shutdown requests when it
should terminate its listener loop.  This was resulting in KILLED
applications on Conductor (and YARN).  Note however, that after
this change, while Conductor applications are gracefully terminated
and indicate FINISHED (confirmed by @charlieeeeeee), YARN 
applications still appear as KILLED.

We'll need to look into why YARN applications are still not shutting
down gracefully.

Fixes #317