### PR TITLE
Implement selection of spark context initialization modes (R)

### DIFF
--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -18,6 +18,6 @@
     "--RemoteProcessProxy.port-range",
     "{port_range}",
     "--RemoteProcessProxy.spark-context-initialization-mode",
-    "{spark_context_initialization_mode}"
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -16,6 +16,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "{spark_context_initialization_mode}"
   ]
 }

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -17,6 +17,6 @@
     "--RemoteProcessProxy.port-range",
     "{port_range}",
     "--RemoteProcessProxy.spark-context-initialization-mode",
-    "{spark_context_initialization_mode}"
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -15,6 +15,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "{spark_context_initialization_mode}"
   ]
 }


### PR DESCRIPTION
This PR is for ISSUE #315.
Context creation can be set to either eager, lazy or none via the kernel.json for both yarn cluster and client modes. "eager" will create a spark session immediately. Default behavior with no option set or "lazy" being set will result in a "lazy" context creation. "none" will skip context creation altogether and start the IRkernel. 

