### PR TITLE
Add support for initialization modes (python, scala)

### DIFF
--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -327,6 +327,17 @@ Other options supported by launchers include:
 * `--RemoteProcessProxy.port-range {port_range}`  - passes configured port-range to launcher where launcher applies 
 that range to kernel ports.  The port-range may be configured globally or on a per-kernelspec basis, as previously
 described.
+* `--RemoteProcessProxy.spark-context-initialization-mode [lazy|eager|none]`  - indicates the *timeframe* in which the
+spark context will be created.  
+    - `lazy` (default) attempts to defer initialization as late as possible - although can vary depending on the 
+    underlying kernel and launcher implementation.
+    - `eager` attempts to create the spark context as soon as possible.
+    - `none` skips spark context creation altogether.
+    
+    Note that some launchers may not be able to support all modes.  For example, the scala launcher uses the Toree 
+    kernel - which currently assumes a spark context will exist.  As a result, a mode of `none` doesn't apply.
+    Similarly, the `lazy` and `eager` modes in the Python launcher are essentially the same, with the spark context
+    creation occurring immediately, but in the background thereby minimizing the kernel's startup time.
 
 Kernel.json files also include a `LAUNCH_OPTS:` section in the `env` stanza to allow for custom 
 parameters to be conveyed in the launcher's environment.  `LAUNCH_OPTS` are then referenced in 

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -13,6 +13,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "eager"
   ]
 }

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -18,6 +18,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -17,6 +17,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_scala_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_client/kernel.json
@@ -18,6 +18,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -18,6 +18,8 @@
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",
-    "{port_range}"
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }


### PR DESCRIPTION
This PR adds support to spark context intialization modes to the python
and scala kernel launchers.  PR #324 added this support to the R kernel
launcher.

- Python launcher: Since the python launcher already performs automatic
spark context creation in the background, modes `lazy` and `eager` behave
the same. Some minor refactoring was required to support `none` so that
the pyspark.sql package wasn't loaded.

- Scala launcher: Support for the initialization modes are provided by
the Toree kernel in either `--spark-context-initialization-mode` (for
lazy and eager) or `--nosparkcontext` (for none).  Since we don't want
to have to set both the launcher and Toree options in the kernel.json
some more significant rework of the arguments processing was required.
This also addressed an issue regarding the support of flag-based
parameters.  Processing of the `--alternate-sigint` parameter was also
refactored such that its processing takes place with all other arguments.

The applicable kernel.json "samples" were updated to relfect the `lazy`
option (since that's the default) with the exception of the Conductor
python file - which wants to use `eager` (although its the same behavior
per above).

Fixes #316