### PR TITLE
Ensure appropriate status codes and messages

### DIFF
--- a/enterprise_gateway/services/processproxies/conductor.py
+++ b/enterprise_gateway/services/processproxies/conductor.py
@@ -6,13 +6,9 @@ import os
 import signal
 import json
 import time
-import tornado
-import logging
 import subprocess
-import errno
 import socket
 import re
-from tornado import web
 from jupyter_client import launch_kernel, localinterfaces
 from .processproxy import RemoteProcessProxy
 
@@ -48,8 +44,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             self.rest_credential = env_dict['EGO_SERVICE_CREDENTIAL']
         else:
             error_message = "ConductorClusterProcessProxy failed to obtain the Conductor credential."
-            self.log.error(error_message)
-            raise tornado.web.HTTPError(500, reason=error_message)
+            self.log_and_raise(http_status_code=500, reason=error_message)
 
         # dynamically update Spark submit parameters
         self.update_launch_info(kernel_cmd, **kw)
@@ -202,8 +197,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                     error_message = "KernelID: '{}', ApplicationID: '{}' unexpectedly found in " \
                                                      "state '{}' during kernel startup!".\
                                     format(self.kernel_id, self.application_id, app_state)
-                    self.log.error(error_message)
-                    raise tornado.web.HTTPError(500, reason=error_message)
+                    self.log_and_raise(http_status_code=500, reason=error_message)
 
                 self.log.debug("{}: State: '{}', Host: '{}', KernelID: '{}', ApplicationID: '{}'".
                                format(i, app_state, self.assigned_host, self.kernel_id, self.application_id))
@@ -245,8 +239,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                         format(self.application_id, self.kernel_launch_timeout)
             self.kill()
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
-            self.log.error(timeout_message)
-            raise tornado.web.HTTPError(error_http_code, reason=timeout_message)
+            self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 
     def get_application_id(self, ignore_final_states=False):
         # Return the kernel's application ID if available, otherwise None.  If we're obtaining application_id

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -6,12 +6,10 @@ import os
 import signal
 import json
 import time
-import tornado
 import logging
 import subprocess
 import errno
 import socket
-from tornado import web
 from jupyter_client import launch_kernel, localinterfaces
 from .processproxy import RemoteProcessProxy
 from yarn_api_client.resource_manager import ResourceManager
@@ -157,8 +155,7 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                     error_message = "KernelID: '{}', ApplicationID: '{}' unexpectedly found in " \
                                                      "state '{}' during kernel startup!".\
                                     format(self.kernel_id, self.application_id, app_state)
-                    self.log.error(error_message)
-                    raise tornado.web.HTTPError(500, reason=error_message)
+                    self.log_and_raise(http_status_code=500, reason=error_message)
 
                 self.log.debug("{}: State: '{}', Host: '{}', KernelID: '{}', ApplicationID: '{}'".
                                format(i, app_state, self.assigned_host, self.kernel_id, self.application_id))
@@ -199,8 +196,7 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                         format(self.application_id, self.kernel_launch_timeout)
             self.kill()
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
-            self.log.error(timeout_message)
-            raise tornado.web.HTTPError(error_http_code, reason=timeout_message)
+            self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 
     def get_application_id(self, ignore_final_states=False):
         # Return the kernel's YARN application ID if available, otherwise None.  If we're obtaining application_id


### PR DESCRIPTION
Visited each of the areas where we raise `HTTPError` or `RuntimeError`
and made sure the error was appropriately logged and messaged back
to client.  With few exceptions, RuntimeErrors were converted to
HTTPErrors with a status code of 500.

Since raising HTTPError does not produce any entry in the server
log, I introduced a base class method `log_and_raise()` that will
both log and raise the exception.  Depending on the value of the
`http_status_code` parameter, the method will raise an `HTTPError`
or `RuntimeError` (although cases of the latter do not currently
exist).

Most status codes remained as is with conversion of `RuntimeError`
cases (primarily port-range validation) to `HTTPError` 500.  Generally
speaking, EG will raise status codes of `403`, `500` and `503`.

Not all of the locations where exceptions are raised could be tested
but I validated a number of them by temporarily sabotaging my
configuration (primarily via malicious edits to `kernel.json`, `run.sh`,
and launcher scripts).

Fixes #311