### PR TITLE
Properly handle max kernels per user on restarts

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -382,9 +382,10 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
             Enforces any limits that may be imposed by the configuration.
         """
 
-        # if kernels-per-user is configured, ensure that this next kernel is still within the limit
+        # if kernels-per-user is configured, ensure that this next kernel is still within the limit.  If this
+        # is due to a restart, skip enforcement since we're re-using that id.
         max_kernels_per_user = self.kernel_manager.parent.parent.max_kernels_per_user
-        if max_kernels_per_user >= 0:
+        if max_kernels_per_user >= 0 and not self.kernel_manager.restarting:
             env_dict = kw.get('env')
             username = env_dict['KERNEL_USERNAME']
             current_kernel_count = self.kernel_manager.parent.parent.kernel_session_manager.active_sessions(username)


### PR DESCRIPTION
During restarts, the max kernels per user enforcement wasn't taking into
account that this kernel startup was due to a restart.  As a result, if
the number of current sessions was already at the threshold, the server
would raise an exception - assuming this startup would count against the
active sessions.  Since restarts re-use the kernel, they should not be
considered in this enforcement.

Fixes #331