### PR TITLE
Small fix for R eager mode not using sparkConfig

### DIFF
--- a/etc/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/etc/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -25,7 +25,7 @@ initialize_spark_session <- function() {
 
     if (identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "eager")) {
         # Start the spark context immediately if set to eager
-        spark <- SparkR::sparkR.session(enableHiveSupport = FALSE)
+        spark <- SparkR::sparkR.session(enableHiveSupport = FALSE, sparkConfig=sparkConfigList)
         assign("spark", spark, envir = .GlobalEnv)
         sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", spark)
         sqlContext <<- SparkR::sparkRSQL.init(sc)


### PR DESCRIPTION
Eager mode was not using default set spark configurations (including the app name) when creating the spark session.