### PR TITLE
Detect missing jar files during scala kernel launch

### DIFF
--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -183,17 +183,18 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         time_interval = RemoteProcessProxy.get_time_diff(self.start_time, RemoteProcessProxy.get_current_time())
 
         if time_interval > self.kernel_launch_timeout:
-            reason = "Application ID is None. Failed to submit a new application to YARN within {} seconds.". \
+            reason = "Application ID is None. Failed to submit a new application to YARN within {} seconds.  " \
+                     "Check Enterprise Gateway log for more information.". \
                 format(self.kernel_launch_timeout)
             error_http_code = 500
             if self.get_application_id(True):
                 if self.query_app_state_by_id(self.application_id) != "RUNNING":
-                    reason = "YARN resources unavailable after {} seconds for app {}, launch timeout: {}!". \
-                        format(time_interval, self.application_id, self.kernel_launch_timeout)
+                    reason = "YARN resources unavailable after {} seconds for app {}, launch timeout: {}!  "\
+                        "Check YARN configuration.".format(time_interval, self.application_id, self.kernel_launch_timeout)
                     error_http_code = 503
                 else:
-                    reason = "App {} is RUNNING, but waited too long ({} secs) to get connection file". \
-                        format(self.application_id, self.kernel_launch_timeout)
+                    reason = "App {} is RUNNING, but waited too long ({} secs) to get connection file.  " \
+                        "Check YARN logs for more information.".format(self.application_id, self.kernel_launch_timeout)
             self.kill()
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)

--- a/etc/kernelspecs/spark_scala_conductor_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_conductor_cluster/bin/run.sh
@@ -20,6 +20,10 @@ fi
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+if [ ! -f ${TOREE_ASSEMBLY} ]; then
+    echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 # The SPARK_OPTS values during installation are stored in __TOREE_SPARK_OPTS__. This allows values to be specified during
 # install, but also during runtime. The runtime options take precedence over the install options.
@@ -36,6 +40,10 @@ JARS="${TOREE_ASSEMBLY}"
 # Toree launcher app path
 LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
 LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+if [ ! -f ${LAUNCHER_APP} ]; then
+    echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \

--- a/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_client/bin/run.sh
@@ -20,6 +20,10 @@ fi
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+if [ ! -f ${TOREE_ASSEMBLY} ]; then
+    echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 # The SPARK_OPTS values during installation are stored in __TOREE_SPARK_OPTS__. This allows values to be specified during
 # install, but also during runtime. The runtime options take precedence over the install options.
@@ -36,6 +40,10 @@ JARS="${TOREE_ASSEMBLY}"
 # Toree launcher app path
 LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
 LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+if [ ! -f ${LAUNCHER_APP} ]; then
+    echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 set -x
 eval exec "${IMPERSONATION_OPTS}" \

--- a/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/bin/run.sh
@@ -20,6 +20,10 @@ fi
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+if [ ! -f ${TOREE_ASSEMBLY} ]; then
+    echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 # The SPARK_OPTS values during installation are stored in __TOREE_SPARK_OPTS__. This allows values to be specified during
 # install, but also during runtime. The runtime options take precedence over the install options.
@@ -36,6 +40,10 @@ JARS="${TOREE_ASSEMBLY}"
 # Toree launcher app path
 LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
 LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+if [ ! -f ${LAUNCHER_APP} ]; then
+    echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 set -x
 eval exec \


### PR DESCRIPTION
Because scala kernel launch is dependent upon the separately installed
Toree jar file, this PR adds a check to ensure that file exists and, if
not, echos an error message and exits the script.  While at it, we also
ensure that the toree kernel launcher jar is present as well.

Since there isn't a very graceful way to communicate this issue, the
changes also include some improved log statements instructing where
users should look to gain details regarding the launch failure.

Fixes #327