### PR TITLE
R kernel fails to find Rscript

### DIFF
--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -6,7 +6,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
+    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.sparkr.r.command=/opt/anaconda2/lib/R/bin/Rscript",
     "SPARK_YARN_USER_ENV": "PATH=/opt/anaconda2/bin:$PATH",
     "LAUNCH_OPTS": ""
   },

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -6,7 +6,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH --conf spark.sparkr.r.command=/opt/anaconda2/lib/R/bin/Rscript",
     "LAUNCH_OPTS": ""
   },
   "argv": [


### PR DESCRIPTION
This change appends the location of the Rscript executable to the configuration
portion (SPARK_OPTS) of the R kernelspecs

Fixes #332