### PR TITLE
Use eager initialization to address idle termination of R kernels

### DIFF
--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -17,6 +17,6 @@
     "--RemoteProcessProxy.port-range",
     "{port_range}",
     "--RemoteProcessProxy.spark-context-initialization-mode",
-    "lazy"
+    "eager"
   ]
 }


### PR DESCRIPTION
By switching the spark-context-initialization-mode parameter from the
current default of `lazy` to `eager`, a spark context will be created
upon startup.  In YARN cluster mode, this prevents YARN from terminating
idle R kernels sitting in `ACCEPTED` states (rather than `RUNNING`).
Apparently, R drivers do not honor the `spark.yarn.am.waitTime` parameter
that we set to 1 day for all kernels.

This change is not necessary for the YARN client R kernel and its
initialization mode remains set to `lazy`.

Fixes #330