### PR TITLE
Ensure message ids match when processing requests

### DIFF
--- a/enterprise_gateway/itests/kernel_client.py
+++ b/enterprise_gateway/itests/kernel_client.py
@@ -3,7 +3,7 @@ import os
 import requests
 
 from uuid import uuid4
-from pprint import pprint
+# from pprint import pprint
 from tornado.escape import json_encode, json_decode, utf8
 from tornado.websocket import websocket_connect
 from tornado.ioloop import IOLoop
@@ -112,7 +112,10 @@ class Kernel:
                 #print('Received message from kernel')
                 #pprint(response_message)
 
-                response_message_id = response_message['parent_header']['msg_id']
+                # Ensure this message is for us (ids match)
+                if 'msg_id' not in response_message['parent_header'] or response_message['parent_header']['msg_id'] != msg_id:
+                    continue
+
                 response_message_type = response_message['msg_type']
 
                 if response_message_type == 'error':


### PR DESCRIPTION
On occasion, all integration tests for a given kernel would fail because
the first response would return the empty string, then all other responses
would be off-by-one from their expected result.  The reason for the skew
appears to be because some messages are returned that do not have the
same message id as the one used during the kernel's creation.  The protocol
is to ensure that responses relative to the same message id correspond to
the kernel. By ensuring that only messages with the same message id are
processed, the skew issue is resolved.

I believe there's an idle status returned where the message id is either
not set or of a non-matching value.  This was resulting in the loop's early
termination with a cell result of the empty string.