### PR TITLE
Changes necessary to build and run docker integration tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - curl -L -o $HOME/.sbt/launchers/1.0.3/sbt-launch.jar http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.3/sbt-launch-1.0.3.jar
 
 install:
-    - pip install --upgrade setuptools pip pycrypto websocket
+    - pip install --upgrade setuptools pip websocket-client
     - make bdist kernelspecs docker-image-enterprise-gateway
     - pip install dist/*.whl coverage
     - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,32 @@
-sudo: false
+sudo: required
 language: python
+
 python:
     - 2.7
-    - 3.3
     - 3.4
-    - 3.5
     - 3.6
 
+services:
+    - docker
+
 env:
+  global:
     - ASYNC_TEST_TIMEOUT=30
+
+before_install:
+    - mkdir -p $HOME/.sbt/launchers/1.0.3
+    - curl -L -o $HOME/.sbt/launchers/1.0.3/sbt-launch.jar http://central.maven.org/maven2/org/scala-sbt/sbt-launch/1.0.3/sbt-launch-1.0.3.jar
+
 install:
-    - pip install --upgrade setuptools pip pycrypto
-    - python setup.py bdist_wheel sdist
+    - pip install --upgrade setuptools pip pycrypto websocket
+    - make bdist kernelspecs docker-image-enterprise-gateway
     - pip install dist/*.whl coverage
     - pip freeze
+
 script:
     - jupyter enterprisegateway --help
     - nosetests -x --process-restartworker --with-coverage --cover-package=enterprise_gateway enterprise_gateway.tests
+    - make itest
     - pip uninstall -y jupyter_enterprise_gateway
 
 after_success:
@@ -24,9 +34,11 @@ after_success:
   - python --version
   - pip --version
   - pip list
+  - docker logs itest
 
 after_failure:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"
   - python --version
   - pip --version
   - pip list
+  - docker logs itest

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ itest: ## Run integration tests (optionally) against docker container
 ifeq (1, $(PREP_DOCKER))
 	make docker-prep
 endif
-	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_HOST) KERNEL_USERNAME=$(ITEST_USER) nosetests -v enterprise_gateway.itests)
+	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_HOST) KERNEL_USERNAME=$(ITEST_USER) nosetests -v -s enterprise_gateway.itests)
 	@echo "Run \`docker logs itest\` to see enterprise-gateway log."
 
 docker-prep: 

--- a/enterprise_gateway/itests/kernel_client.py
+++ b/enterprise_gateway/itests/kernel_client.py
@@ -5,10 +5,15 @@ import requests
 from uuid import uuid4
 from pprint import pprint
 from tornado.escape import json_encode, json_decode, utf8
-from tornado.websocket import websocket_connect
-from tornado.ioloop import IOLoop
-from tornado.httpclient import HTTPRequest
+from threading import Thread
+import websocket
 
+try:  # prefer python 3, fallback to 2
+    import queue as queue
+except ImportError:
+    import Queue as queue
+
+DEFAULT_TIMEOUT = 60 * 60
 
 class KernelLauncher:
     DEFAULT_USERNAME = os.getenv('KERNEL_USERNAME', 'bob')
@@ -17,25 +22,32 @@ class KernelLauncher:
     def __init__(self, host=DEFAULT_GATEWAY_HOST):
         self.http_api_endpoint = 'http://{}/api/kernels'.format(host)
         self.ws_api_endpoint = 'ws://{}/api/kernels'.format(host)
+        self.kernel = None
 
-    def launch(self, kernelspec_name, username=DEFAULT_USERNAME):
+    def launch(self, kernelspec_name, username=DEFAULT_USERNAME, timeout=DEFAULT_TIMEOUT):
         print('Launching a {} kernel ....'.format(kernelspec_name))
-        kernel_id = None
+
         json_data = {'name': kernelspec_name}
         if username is not None:
             json_data['env'] = {'KERNEL_USERNAME': username}
+
         response = requests.post(self.http_api_endpoint, data=json_encode(json_data))
         if response.status_code == 201:
             json_data = response.json()
             kernel_id = json_data.get("id")
             print('Launched kernel with id {}'.format(kernel_id))
         else:
-            raise RuntimeError('Error creating kernel : {} response code \n {}'.format(response.status_code, response.content))
+            raise RuntimeError('Error creating kernel : {} response code \n {}'.
+                               format(response.status_code, response.content))
 
-        return Kernel(self.ws_api_endpoint, kernel_id)
+        self.kernel = Kernel(self.ws_api_endpoint, kernel_id, timeout)
+        return self.kernel
 
     def shutdown(self, kernel_id):
         print("Shutting down kernel : {} ....".format(kernel_id))
+        if self.kernel:
+            self.kernel.shutdown()
+
         if not kernel_id:
             return False
         url = "{}/{}".format(self.http_api_endpoint, kernel_id)
@@ -48,16 +60,177 @@ class KernelLauncher:
 
 
 class Kernel:
-    DEFAULT_TIMEOUT = 60 * 60
 
-    def __init__(self, ws_api_endpoint, kernel_id):
+    DEAD_MSG_ID = 'deadbeefdeadbeefdeadbeefdeadbeef'
+    POST_IDLE_TIMEOUT = 0.5
+
+    def __init__(self, ws_api_endpoint, kernel_id, timeout=DEFAULT_TIMEOUT):
+
+        self.shutting_down = False
         self.ws_api_endpoint = ws_api_endpoint
         self.kernel_api_endpoint = '{}/{}/channels'.format(ws_api_endpoint, kernel_id)
         self.kernel_id = kernel_id
         print('Initializing kernel client ({}) to {}'.format(kernel_id, self.kernel_api_endpoint))
 
+        self.kernel_socket = websocket.create_connection(self.kernel_api_endpoint, timeout=timeout,
+                                                         enable_multithread=True)
 
-    def __create_execute_request(self, msg_id, code):
+        self.response_queues = {}
+
+        # startup reader thread
+        self.response_reader = Thread(target=self._read_responses)
+        self.response_reader.start()
+
+    def shutdown(self):
+        # Terminate thread, close socket and clear queues.
+        self.shutting_down = True
+
+        if self.kernel_socket:
+            self.kernel_socket.close()
+            self.kernel_socket = None
+
+        if self.response_queues:
+            self.response_queues.clear()
+            self.response_queues = None
+
+        if self.response_reader:
+            self.response_reader = None
+
+    def execute(self, code, timeout=DEFAULT_TIMEOUT):
+        """
+        Executes the code provided and returns the result of that execution.
+        """
+        response = []
+        try:
+            msg_id = self._send_request(code)
+
+            post_idle = False
+            while True:
+                response_message = self._get_response(msg_id, timeout, post_idle)
+                if response_message:
+                    response_message_type = response_message['msg_type']
+
+                    if response_message_type == 'error':
+                        raise RuntimeError('ERROR: {}:{}'.format(response_message['content']['ename'],
+                                                                 response_message['content']['evalue']))
+
+                    if response_message_type == 'stream':
+                        response.append(Kernel._convert_raw_response(response_message['content']['text']))
+
+                    elif response_message_type == 'execute_result' or response_message_type == 'display_data':
+                        if 'text/plain' in response_message['content']['data']:
+                            response.append(
+                                Kernel._convert_raw_response(response_message['content']['data']['text/plain']))
+                        elif 'text/html' in response_message['content']['data']:
+                            response.append(
+                                Kernel._convert_raw_response(response_message['content']['data']['text/html']))
+
+                    elif response_message_type == 'status':
+                        if response_message['content']['execution_state'] == 'idle':
+                            post_idle = True  # indicate we're at the logical end and timeout poll for next message
+                            continue
+
+                if post_idle and response_message is None:
+                    break
+
+        except BaseException as b:
+            print(b)
+
+        return '\n'.join(response)
+
+    def _send_request(self, code):
+        """
+        Builds the request and submits it to the kernel.  Prior to sending the request it
+        creates an empty response queue and adds it to the dictionary using msg_id as the
+        key.  The msg_id is returned in order to read responses.
+        """
+        msg_id = uuid4().hex
+        message = Kernel.__create_execute_request(msg_id, code)
+
+        # create response-queue and add to map for this msg_id
+        self.response_queues[msg_id] = queue.Queue()
+
+        self.kernel_socket.send(message)
+
+        return msg_id
+
+    def _get_response(self, msg_id, timeout, post_idle):
+        """
+        Pulls the next response message from the queue corresponding to msg_id.  If post_idle is true,
+        the timeout parameter is set to a very short value since a majority of time, there won't be a
+        message in the queue.  However, in cases where a race condition occurs between the idle status
+        and the execute_result payload - where the two are out of order, then this will pickup the result.
+        """
+
+        if post_idle and timeout > Kernel.POST_IDLE_TIMEOUT:
+            timeout = Kernel.POST_IDLE_TIMEOUT  # overwrite timeout to small value following idle messages.
+
+        msg_queue = self.response_queues.get(msg_id)
+        try:
+            response = msg_queue.get(timeout=timeout)
+
+            print_str = '\n<<<<<<<<<<<<<<< POST IDLE MESSAGE >>>>>>>>>>>>>>>' if post_idle else '\n<<<<<<<<<<<<<<<'
+            print(print_str)
+            print('Pulled response from queue for kernel with msg_id: {}'.format(msg_id))
+            pprint(response)
+
+        except queue.Empty:
+            response = None
+
+        return response
+
+    def _read_responses(self):
+        """
+        Reads responses from the websocket.  For each response read, it is added to the response queue based
+        on the messages parent_header.msg_id.  It does this for the duration of the class's lifetime until its
+        shutdown method is called, at which time the socket is closed (unblocking the reader) and the thread
+        terminates.  If shutdown happens to occur while processing a response (unlikely), termination takes
+        place via the loop control boolean.
+        """
+        try:
+            while not self.shutting_down:
+                raw_message = self.kernel_socket.recv()
+                response_message = json_decode(utf8(raw_message))
+
+                msg_id = Kernel._get_msg_id(response_message)
+
+                if msg_id not in self.response_queues:  # this will happen when the msg_id is generated by the server
+                    self.response_queues[msg_id] = queue.Queue()
+
+                # insert into queue
+                self.response_queues.get(msg_id).put_nowait(response_message)
+
+            print('Response reader thread exiting...')
+
+        except websocket.WebSocketConnectionClosedException:
+            pass  # websocket closure most likely due to shutdown
+
+        except BaseException as be:
+            if not self.shutting_down:
+                print('Unexpected exception encountered ({})'.format(be))
+
+        print('Response reader thread exiting...')
+
+    @staticmethod
+    def _get_msg_id(message):
+
+        msg_id = Kernel.DEAD_MSG_ID
+        if message and 'msg_id' in message['parent_header'] and message['parent_header']['msg_id']:
+            msg_id = message['parent_header']['msg_id']
+
+        return msg_id
+
+    @staticmethod
+    def _convert_raw_response(raw_response_message):
+        result = raw_response_message
+        if isinstance(raw_response_message, str):
+            if "u'" in raw_response_message:
+                result = raw_response_message.replace("u'", "")[:-1]
+
+        return result
+
+    @staticmethod
+    def __create_execute_request(msg_id, code):
         return json_encode({
             'header': {
                 'username': '',
@@ -78,83 +251,3 @@ class Kernel:
             'metadata': {},
             'buffers': {}
         })
-
-    def execute(self, code, timeout=DEFAULT_TIMEOUT):
-
-        response = []
-
-        #print('')
-        #print('Submitting code:\n{}'.format(code))
-        #print('')
-
-        try:
-            ws_req = HTTPRequest(self.kernel_api_endpoint)
-            kernel_socket_future = websocket_connect(ws_req)
-            kernel_socket = IOLoop.current().run_sync(lambda: kernel_socket_future, timeout)
-
-            #pprint('')
-            #print('>>>>> Sending message to kernel')
-            msg_id = uuid4().hex
-            message = self.__create_execute_request(msg_id, code)
-            #pprint(message)
-            future = kernel_socket.write_message(message)
-            response_message = IOLoop.current().run_sync(lambda: future, timeout)
-            pprint('>>>>>>>>>>>>>>>>>>>')
-            print('Received message from kernel with msg_id:{}'.format(msg_id))
-            pprint(response_message)
-
-            while True:
-                msg_future = kernel_socket.read_message()
-                response_message = IOLoop.current().run_sync(lambda: msg_future, timeout)
-
-                response_message = json_decode(utf8(response_message))
-
-                pprint('>>>>>>>>>>>>>>>>>>>')
-                print('Received message from kernel with msg_id:{}'.format(msg_id))
-                pprint(response_message)
-
-                # Ensure this message is for us (ids match)
-                if 'msg_id' not in response_message['parent_header'] or response_message['parent_header']['msg_id'] != msg_id:
-                    continue
-
-                response_message_type = response_message['msg_type']
-
-                if response_message_type == 'error':
-                    raise RuntimeError('ERROR: {}:{}'.format(response_message['content']['ename'], response_message['content']['evalue']))
-
-                if response_message_type == 'stream':
-                    response.append(self._process_response_message(response_message['content']['text']))
-
-                if response_message_type == 'execute_result' or response_message_type == 'display_data':
-                    if 'text/plain' in response_message['content']['data']:
-                        response.append(self._process_response_message(response_message['content']['data']['text/plain']))
-                    elif 'text/html' in response_message['content']['data']:
-                        response.append(self._process_response_message(response_message['content']['data']['text/html']))
-
-                elif response_message_type == 'status':
-                    if response_message['content']['execution_state'] == 'idle':
-                        break
-
-        except BaseException as b:
-            print(b)
-
-        #finally:
-        #    if kernel_socket_future:
-        #        try:
-        #            kernel_socket_future.close()
-        #            kernel_socket_future = None
-        #        finally:
-        #            # ignore
-        #            print('Error closing kernel socket.')
-
-
-        return '\n'.join(response)
-
-
-    def _process_response_message(self, raw_response_message):
-        result = raw_response_message
-        if isinstance(raw_response_message, str):
-            if "u'" in raw_response_message:
-                result = raw_response_message.replace("u'", "")[:-1]
-
-        return result

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
@@ -16,27 +15,27 @@ class PythonKernelBaseTestCase(object):
 
     def test_hello_world(self):
         result = self.kernel.execute("print('Hello World')")
-        assert re.search('Hello World', result)
+        self.assertRegexpMatches(result, 'Hello World')
 
     def test_get_application_id(self):
         result = self.kernel.execute("print(sc.applicationId)")
-        assert re.search('application_', result)
+        self.assertRegexpMatches(result, 'application_')
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sc.version")
-        assert re.search('2.1.*', result)
+        self.assertRegexpMatches(result, '2.1.*')
 
     def test_get_resource_manager(self):
         result = self.kernel.execute("sc.getConf().get('spark.master')")
-        assert re.search('yarn.*', result)
+        self.assertRegexpMatches(result, 'yarn.*')
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute("sc.getConf().get('spark.submit.deployMode')")
-
+        self.assertRegexpMatches(result, '(cluster|client)')
 
     def test_get_host_address(self):
         result = self.kernel.execute("print(sc.getConf().get('spark.driver.host'))")
-        assert re.match('^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$', result)
+        self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
 class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseTestCase):

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
@@ -16,27 +15,27 @@ class RKernelBaseTestCase(object):
 
     def test_hello_world(self):
         result = self.kernel.execute('print("Hello World", quote = FALSE)')
-        assert re.search('Hello World', result)
+        self.assertRegexpMatches(result, 'Hello World')
 
     def test_get_application_id(self):
         result = self.kernel.execute('SparkR:::callJMethod(SparkR:::callJMethod(sc, "sc"), "applicationId")')
-        assert re.search('application_', result)
+        self.assertRegexpMatches(result, 'application_')
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sparkR.version()")
-        assert re.search('2.1', result)
+        self.assertRegexpMatches(result, '2.1')
 
     def test_get_resource_manager(self):
         result = self.kernel.execute('unlist(sparkR.conf("spark.master"))')
-        assert re.search('yarn', result)
+        self.assertRegexpMatches(result, 'yarn')
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute('unlist(sparkR.conf("spark.submit.deployMode"))')
-        assert re.findall('(cluster|client)', result)
+        self.assertRegexpMatches(result, '(cluster|client)')
 
     def test_get_host_address(self):
         result = self.kernel.execute('unlist(sparkR.conf("spark.driver.host"))')
-        assert re.findall('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', result)
+        self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
 class TestRKernelClient(unittest.TestCase, RKernelBaseTestCase):

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
@@ -16,27 +15,27 @@ class ScalaKernelBaseTestCase(object):
 
     def test_hello_world(self):
         result = self.kernel.execute('println("Hello World")')
-        assert re.search('Hello World', result)
+        self.assertRegexpMatches(result, 'Hello World')
 
     def test_get_application_id(self):
         result = self.kernel.execute('sc.applicationId')
-        assert re.search('application_', result)
+        self.assertRegexpMatches(result, 'application_')
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sc.version")
-        assert re.search('2.1', result)
+        self.assertRegexpMatches(result, '2.1')
 
     def test_get_resource_manager(self):
         result = self.kernel.execute('sc.getConf.get("spark.master")')
-        assert re.search('yarn', result)
+        self.assertRegexpMatches(result, 'yarn')
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute('sc.getConf.get("spark.submit.deployMode")')
-        assert re.findall('(cluster|client)', result)
+        self.assertRegexpMatches(result, '(cluster|client)')
 
     def test_get_host_address(self):
         result = self.kernel.execute('sc.getConf.get("spark.driver.host")')
-        assert re.findall('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', result)
+        self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
 class TestScalaKernelClient(unittest.TestCase, ScalaKernelBaseTestCase):


### PR DESCRIPTION
Extended travis configuration to include docker attributes, and use
makefile for running integration tests.

Removed testing for Python 3.3 since it has been deprecated and 3.5
since it's in between 3.4 and 3.6.

Changed assert statements to use self.assertRegexpMatches - which
will then print the result string on failures.

Added -s flag to nosetest so that print statements are displayed.

Note: travis build/test times have now increased from around 5 minutes
to closer to 20 - with about 10 minutes spent building the two docker
images.  We'll probably want to try to improve that, especially as
the tests increase in size.

Fixes #293