### PR TITLE
Restored code to send alternate interrupt signal numbers for local cases

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -164,7 +164,30 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         """
         self.log.debug("RemoteKernelManager.signal_kernel({})".format(signum))
         if self.has_kernel:
-            self.kernel.send_signal(signum)
+            if signum == signal.SIGINT:
+                if self.sigint_value is None:
+                    # If we're interrupting the kernel, check if kernelspec's env defines
+                    # an alternate interrupt signal.  We'll do this once per interrupted kernel.
+                    self.sigint_value = signum  # use default
+                    alt_sigint = self.kernel_spec.env.get('EG_ALTERNATE_SIGINT')
+                    if alt_sigint:
+                        try:
+                            sig_value = getattr(signal, alt_sigint)
+                            if type(sig_value) is int:  # Python 2
+                                self.sigint_value = sig_value
+                            else:  # Python 3
+                                self.sigint_value = sig_value.value
+                            self.log.debug(
+                                "Converted EG_ALTERNATE_SIGINT '{}' to value '{}' to use as interrupt signal.".
+                                format(alt_sigint, self.sigint_value))
+                        except AttributeError:
+                            self.log.warning("Error received when attempting to convert EG_ALTERNATE_SIGINT of "
+                                             "'{}' to a value. Check kernelspec entry for kernel '{}' - using "
+                                             "default 'SIGINT'".
+                                             format(alt_sigint, self.kernel_spec.display_name))
+                self.kernel.send_signal(self.sigint_value)
+            else:
+                self.kernel.send_signal(signum)
         else:
             raise RuntimeError("Cannot signal kernel. No kernel is running!")
 

--- a/etc/kernel-launchers/scala/toree-launcher/build.sbt
+++ b/etc/kernel-launchers/scala/toree-launcher/build.sbt
@@ -16,6 +16,6 @@ val sparkVersion = "2.1.1"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.10" // Apache v2
-libraryDependencies += "org.apache.toree" %% "toree-assembly" % "0.2.0-incubating" from "https://repository.apache.org/content/repositories/orgapachetoree-1012/org/apache/toree/toree-assembly/0.2.0-incubating/toree-assembly-0.2.0-incubating.jar"
+libraryDependencies += "org.apache.toree" %% "toree-assembly" % "0.2.0-incubating" from "https://repository.apache.org/content/repositories/orgapachetoree-1010/org/apache/toree/toree-assembly/0.2.0-incubating/toree-assembly-0.2.0-incubating.jar"
 
 unmanagedJars in Compile += file("lib/toree-assembly.jar")


### PR DESCRIPTION
Since EG still supports local kernels (that go through LocalProcessProxy)
without a launcher, we still need to support the ability to specify an
alternate signal number.  As a result, the code to look for `EG_ALTERNATE_SIGINT`
in the kernel.json's `env` stanza has been restored.  When present, this
informs EG that a different signal (the value of the env variable) be sent
instead of `SIGINT`.  In nearly all cases, the value of this variable will
be `SIGUSR2`.

Also updated the reference of toree when building the launcher.