### PR TITLE
Add tests for local kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ itest: ## Run integration tests (optionally) against docker container
 ifeq (1, $(PREP_DOCKER))
 	make docker-prep
 endif
-	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_HOST) KERNEL_USERNAME=$(ITEST_USER) nosetests -v -s enterprise_gateway.itests)
+	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_HOST) KERNEL_USERNAME=$(ITEST_USER) nosetests -v enterprise_gateway.itests)
 	@echo "Run \`docker logs itest\` to see enterprise-gateway log."
 
 docker-prep: 

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -1,5 +1,5 @@
 import unittest
-
+import os
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
 
@@ -13,11 +13,11 @@ class PythonKernelBaseTestCase(object):
         self.assertRegexpMatches(result, 'Hello World')
 
     def test_restart(self):
-        """
-        1. Set a variable to a known value.
-        2. Restart the kernel
-        3. Attempt to increment the variable, verify an error was received (due to undefined variable)
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Restart the kernel
+        # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
+
         self.kernel.execute("x = 123")
         original_value = int(self.kernel.execute("print(x)"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -28,13 +28,13 @@ class PythonKernelBaseTestCase(object):
         self.assertRegexpMatches(error_result, 'NameError')
 
     def test_interrupt(self):
-        """
-        1. Set a variable to a known value.
-        2. Spawn a thread that will perform an interrupt after some number of seconds,
-        3. Issue a long-running command - that spans during of interrupt thread wait time,
-        4. Interrupt the kernel,
-        5. Attempt to increment the variable, verify expected result.
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Spawn a thread that will perform an interrupt after some number of seconds,
+        # 3. Issue a long-running command - that spans during of interrupt thread wait time,
+        # 4. Interrupt the kernel,
+        # 5. Attempt to increment the variable, verify expected result.
+
         self.kernel.execute("x = 123")
         original_value = int(self.kernel.execute("print(x)"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -89,8 +89,30 @@ class PythonKernelBaseYarnTestCase(PythonKernelBaseTestCase):
         self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
+class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
+    KERNELSPEC = os.getenv("PYTHON_KERNEL_LOCAL_NAME", "python2")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPythonKernelLocal, cls).setUpClass()
+        print('>>>')
+        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # initialize environment
+        cls.launcher = KernelLauncher()
+        cls.kernel = cls.launcher.launch(cls.KERNELSPEC)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestPythonKernelLocal, cls).tearDownClass()
+        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # shutdown environment
+        cls.launcher.shutdown(cls.kernel.kernel_id)
+
+
 class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseYarnTestCase):
-    KERNELSPEC = "spark_python_yarn_client"
+    KERNELSPEC = os.getenv("PYTHON_KERNEL_CLIENT_NAME", "spark_python_yarn_client")
 
     @classmethod
     def setUpClass(cls):
@@ -112,7 +134,7 @@ class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseYarnTestCase):
 
 
 class TestPythonKernelCluster(unittest.TestCase, PythonKernelBaseYarnTestCase):
-    KERNELSPEC = "spark_python_yarn_cluster"
+    KERNELSPEC = os.getenv("PYTHON_KERNEL_CLUSTER_NAME", "spark_python_yarn_cluster")
 
     @classmethod
     def setUpClass(cls):

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -1,5 +1,5 @@
 import unittest
-
+import os
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
 
@@ -13,11 +13,11 @@ class RKernelBaseTestCase(object):
         self.assertRegexpMatches(result, 'Hello World')
 
     def test_restart(self):
-        """
-        1. Set a variable to a known value.
-        2. Restart the kernel
-        3. Attempt to increment the variable, verify an error was received (due to undefined variable)
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Restart the kernel
+        # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
+
         self.kernel.execute("x = 123")
         original_value = int(self.kernel.execute("write(x,stdout())"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -28,13 +28,13 @@ class RKernelBaseTestCase(object):
         self.assertRegexpMatches(error_result, 'Error in eval')
 
     def test_interrupt(self):
-        """
-        1. Set a variable to a known value.
-        2. Spawn a thread that will perform an interrupt after some number of seconds,
-        3. Issue a long-running command - that spans during of interrupt thread wait time,
-        4. Interrupt the kernel,
-        5. Attempt to increment the variable, verify expected result.
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Spawn a thread that will perform an interrupt after some number of seconds,
+        # 3. Issue a long-running command - that spans during of interrupt thread wait time,
+        # 4. Interrupt the kernel,
+        # 5. Attempt to increment the variable, verify expected result.
+
         self.kernel.execute("x = 123")
         original_value = int(self.kernel.execute("write(x,stdout())"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -88,30 +88,50 @@ class RKernelBaseYarnTestCase(RKernelBaseTestCase):
         self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
+class TestRKernelLocal(unittest.TestCase, RKernelBaseTestCase):
+    KERNELSPEC = os.getenv("R_KERNEL_LOCAL_NAME", "ir")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRKernelLocal, cls).setUpClass()
+        print('>>>')
+        print('Starting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # initialize environment
+        cls.launcher = KernelLauncher()
+        cls.kernel = cls.launcher.launch(cls.KERNELSPEC)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestRKernelLocal, cls).tearDownClass()
+        print('Shutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        # shutdown environment
+        cls.launcher.shutdown(cls.kernel.kernel_id)
+
+
 class TestRKernelClient(unittest.TestCase, RKernelBaseYarnTestCase):
-    GATEWAY_HOST = "localhost:8888"
-    KERNELSPEC = "spark_R_yarn_client"
+    KERNELSPEC = os.getenv("R_KERNEL_CLIENT_NAME", "spark_R_yarn_client")
 
     @classmethod
     def setUpClass(cls):
         super(TestRKernelClient, cls).setUpClass()
         print('>>>')
-        print('Starting R kernel at {} using {} kernelspec'.format(cls.GATEWAY_HOST, cls.KERNELSPEC))
+        print('Starting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
-        cls.launcher = KernelLauncher(cls.GATEWAY_HOST)
+        cls.launcher = KernelLauncher()
         cls.kernel = cls.launcher.launch(cls.KERNELSPEC)
 
     @classmethod
     def tearDownClass(cls):
         super(TestRKernelClient, cls).tearDownClass()
-        print('Shutting down R kernel at {} using {} kernelspec'.format(cls.GATEWAY_HOST, cls.KERNELSPEC))
+        print('Shutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
         # shutdown environment
         cls.launcher.shutdown(cls.kernel.kernel_id)
 
 
 class TestRKernelCluster(unittest.TestCase, RKernelBaseYarnTestCase):
-    KERNELSPEC = "spark_R_yarn_cluster"
+    KERNELSPEC = os.getenv("R_KERNEL_CLUSTER_NAME", "spark_R_yarn_cluster")
 
     @classmethod
     def setUpClass(cls):

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -1,5 +1,5 @@
 import unittest
-
+import os
 from enterprise_gateway.itests.kernel_client import KernelLauncher
 
 
@@ -13,11 +13,11 @@ class ScalaKernelBaseTestCase(object):
         self.assertRegexpMatches(result, 'Hello World')
 
     def test_restart(self):
-        """
-        1. Set a variable to a known value.
-        2. Restart the kernel
-        3. Attempt to increment the variable, verify an error was received (due to undefined variable)
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Restart the kernel
+        # 3. Attempt to increment the variable, verify an error was received (due to undefined variable)
+
         self.kernel.execute("var x = 123")
         original_value = int(self.kernel.execute("x"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -28,13 +28,13 @@ class ScalaKernelBaseTestCase(object):
         self.assertRegexpMatches(error_result, 'Compile Error')
 
     def test_interrupt(self):
-        """
-        1. Set a variable to a known value.
-        2. Spawn a thread that will perform an interrupt after some number of seconds,
-        3. Issue a long-running command - that spans during of interrupt thread wait time,
-        4. Interrupt the kernel,
-        5. Attempt to increment the variable, verify expected result.
-        """
+
+        # 1. Set a variable to a known value.
+        # 2. Spawn a thread that will perform an interrupt after some number of seconds,
+        # 3. Issue a long-running command - that spans during of interrupt thread wait time,
+        # 4. Interrupt the kernel,
+        # 5. Attempt to increment the variable, verify expected result.
+
         self.kernel.execute("var x = 123")
         original_value = int(self.kernel.execute("x"))  # This will only return the value.
         self.assertEquals(original_value, 123)
@@ -88,8 +88,30 @@ class ScalaKernelBaseYarnTestCase(ScalaKernelBaseTestCase):
         self.assertRegexpMatches(result, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
 
 
+class TestScalaKernelLocal(unittest.TestCase, ScalaKernelBaseTestCase):
+    KERNELSPEC = os.getenv("SCALA_KERNEL_LOCAL_NAME", "spark_2.1_scala")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestScalaKernelLocal, cls).setUpClass()
+        print('>>>')
+        print('Starting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # initialize environment
+        cls.launcher = KernelLauncher()
+        cls.kernel = cls.launcher.launch(cls.KERNELSPEC)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestScalaKernelLocal, cls).tearDownClass()
+        print('Shutting down Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        # shutdown environment
+        cls.launcher.shutdown(cls.kernel.kernel_id)
+
+
+
 class TestScalaKernelClient(unittest.TestCase, ScalaKernelBaseYarnTestCase):
-    KERNELSPEC = "spark_scala_yarn_client"
+    KERNELSPEC = os.getenv("SCALA_KERNEL_CLIENT_NAME", "spark_scala_yarn_client")
 
     @classmethod
     def setUpClass(cls):
@@ -110,7 +132,7 @@ class TestScalaKernelClient(unittest.TestCase, ScalaKernelBaseYarnTestCase):
 
 
 class TestScalaKernelCluster(unittest.TestCase, ScalaKernelBaseYarnTestCase):
-    KERNELSPEC = "spark_scala_yarn_cluster"
+    KERNELSPEC = os.getenv("SCALA_KERNEL_CLUSTER_NAME", "spark_scala_yarn_cluster")
 
     @classmethod
     def setUpClass(cls):

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -11,7 +11,7 @@ COPY start-enterprise-gateway.sh.template /usr/local/share/jupyter/
 # Massage kernelspecs to docker image env...
 # Create symbolic link to preserve hdp-related directories
 # Copy toree jar from install to scala kernelspec lib directory
-# Add YARN_CONF_DIR to each env stanza, Add PATH to R-yarn-client env stanza
+# Add YARN_CONF_DIR to each env stanza, Add PATH to R-yarn-client env stanza, Add alternate-sigint to vanilla toree
 RUN mkdir -p /usr/hdp/current /tmp/byok/kernels && \
 	ln -s /usr/local/spark-2.1.0-bin-hadoop2.7 /usr/hdp/current/spark2-client && \
 	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/lib && \
@@ -19,6 +19,7 @@ RUN mkdir -p /usr/hdp/current /tmp/byok/kernels && \
 	cd /usr/local/share/jupyter/kernels && \
 	for dir in spark_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
 	cat spark_R_yarn_client/kernel.json | sed s/'"env": {'/'"env": {|    "PATH": "\/opt\/anaconda2\/bin:$PATH",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_R_yarn_client/kernel.json && \
+	cat spark_2.1_scala/kernel.json | sed s/'"__TOREE_OPTS__": "",'/'"__TOREE_OPTS__": "--alternate-sigint USR2",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_2.1_scala/kernel.json && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
 	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
 


### PR DESCRIPTION
Added tests for local (vanilla) Python, R and Scala (Toree) kernels building
on refactoring delivered by PR #353.

Updated the vanilla toree kernel.json to include `--alternate-sigint USR2`
so that interrupt test passes.

Added ability to override default kernel names for each test class via
env variables.

Removed -s option on itest to eliminate a majority of the log output now
that general framework appears to be working.  If stdout is desired, it
can be enabled via -s or --nocapture.