### PR TITLE
Fix unauthorized_users list

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -113,7 +113,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         # Take union of unauthorized users...
         self.unauthorized_users = self.kernel_manager.parent.parent.unauthorized_users
         if proxy_config.get('unauthorized_users'):
-            self.unauthorized_users.union(set(proxy_config.get('unauthorized_users').split(',')))
+            self.unauthorized_users = self.unauthorized_users.union(proxy_config.get('unauthorized_users').split(','))
 
         # Let authorized users override global value - if set on kernelspec...
         if proxy_config.get('authorized_users'):


### PR DESCRIPTION
The authorized and unauthorized users lists are implemented using Sets.
Since sets are immutable, the code was performing a union between the
globally scoped unauthorized_users list with the one defined in the
process proxy. However, it wasn't re-initializing the variable that is
then used downstream.  As a result, the code behaved as if the process
proxy-defined list was not in use.

Since unions are not performed on the authorized_users lists, this issue
is not present there.

Fixes #356