### PR TITLE
Add initial authorization tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,5 +135,5 @@ endif
 docker-prep: 
 	@-docker rm -f itest >> /dev/null
 	@echo "Starting enterprise-gateway container (run \`docker logs itest\` to see container log)..."
-	@-docker run -itd -p 8888:8888 -h itest --name itest elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG) --elyra
+	@-docker run -itd -p 8888:8888 -h itest --name itest -v `pwd`/enterprise_gateway/itests:/tmp/byok elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG) --elyra
 	@(r="1"; attempts=0; while [ "$$r" == "1" -a $$attempts -lt 30 ]; do echo "Waiting for enterprise-gateway to start..."; sleep 2; ((attempts++)); docker logs itest |grep 'Jupyter Enterprise Gateway at http'; r=$$?; done; if [ $$attempts -ge 30 ]; then echo "Wait for startup timed out!"; exit 1; fi;)

--- a/enterprise_gateway/itests/kernels/authorization_test/kernel.json
+++ b/enterprise_gateway/itests/kernels/authorization_test/kernel.json
@@ -1,0 +1,20 @@
+{
+  "display_name": "Authorization Testing",
+  "language": "python",
+  "process_proxy": {
+    "class_name": "enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy",
+    "config": {
+      "authorized_users": "bob,alice,bad_guy",
+      "unauthorized_users": "bad_guy"
+    }
+  },
+  "env": {
+  },
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ]
+}

--- a/enterprise_gateway/itests/test_authorization.py
+++ b/enterprise_gateway/itests/test_authorization.py
@@ -1,0 +1,45 @@
+import unittest
+import os
+from enterprise_gateway.client.gateway_client import GatewayClient
+
+
+class TestAuthorization(unittest.TestCase):
+    KERNELSPEC = os.getenv("AUTHORIZATION_KERNEL_NAME", "authorization_test")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestAuthorization, cls).setUpClass()
+        print('>>>')
+
+        # initialize environment
+        cls.gateway_client = GatewayClient()
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_authorized_users(self):
+        kernel = None
+        try:
+            kernel = self.gateway_client.start_kernel(TestAuthorization.KERNELSPEC, username='bob')
+            result = kernel.execute("print('The cow jumped over the moon.')")
+            self.assertEquals(result, "The cow jumped over the moon.\n")
+        finally:
+            if kernel:
+                kernel.shutdown()
+
+    def test_unauthorized_users(self):
+        kernel = None
+        try:
+            kernel = self.gateway_client.start_kernel(TestAuthorization.KERNELSPEC, username='bad_guy')
+            self.assertTrue(False, msg="Unauthorization exception expected!")
+        except Exception as be:
+            self.assertRegexpMatches(be.args[0], "403")
+        finally:
+            if kernel:
+                kernel.shutdown()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added tests to validate the use of the authorized_users and unauthorized_users
lists that can be configured in the process-proxy:config stanza of a kernelspec.

This change also uses local kernelspec definitions that are mounted into the
docker image via the byok (bring-your-own-kernelspec) capabilities recently
added to image.  The idea is that different test-specific kernelspecs can be
added when necessary.

An actual bug (Issue #356) was identified during development of these changes.

Note: The travis builds associated with this PR will fail until PR #357 has
been merged since that contains the fix for the unauthorized_users list that
is tested as part of these changes.