### PR TITLE
Update docs to include kubernetes support information

### DIFF
--- a/docs/source/debug.md
+++ b/docs/source/debug.md
@@ -1,4 +1,6 @@
 ## Debugging Jupyter Enterprise Gateway
+This page discusses how to go about debugging Enterprise Gateway.  We also provide troubleshooting information
+on our [Troubleshooting](troubleshooting.html) page.
 
 ### Configuring your IDE for debugging Jupyter Enterprise Gateway
 

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -27,25 +27,38 @@ Entering `make` with no parameters yields the following:
 
 ```
 activate                       eval `make activate`
+clean-docker                   Remove docker images
+clean-enterprise-gateway       Remove elyra/enterprise-gateway:dev docker image
+clean-kubernetes-enterprise-gateway Remove elyra/kubernetes-enterprise-gateway:dev docker image
+clean-kubernetes-kernel-py     Remove elyra/kubernetes-kernel-py:dev docker image
+clean-kubernetes-kernel-r      Remove elyra/kubernetes-kernel-r:dev docker image
+clean-kubernetes-kernel-scala  Remove elyra/kubernetes-kernel-scala:dev docker image
+clean-kubernetes-kernel-tf-py  Remove elyra/kubernetes-kernel-tf-py:dev docker image
+clean-kubernetes               Remove kubernetes docker images
+clean-nb2kg                    Remove elyra/nb2kg:dev docker image
+clean-yarn-spark               Remove elyra/yarn-spark:2.1.0 docker image
 clean                          Make a clean source tree
 dev                            Make a server in jupyter_websocket mode
-dist                           Make binary and source distribution to dist folder
-docker-clean-enterprise-gateway Remove elyra/enterprise-gateway:dev docker image
-docker-clean-nb2kg             Remove elyra/nb2kg:dev docker image
-docker-clean-yarn-spark        Remove elyra/yarn-spark:2.1.0 docker image
-docker-clean                   Remove docker images
-docker-image-enterprise-gateway Build elyra/enterprise-gateway:dev docker image
-docker-image-nb2kg             Build elyra/nb2kg:dev docker image 
-docker-image-yarn-spark        Build elyra/yarn-spark:2.1.0 docker image
+dist                           Make source, binary and kernelspecs distribution to dist folder
 docker-images                  Build docker images
 docs                           Make HTML documentation
+enterprise-gateway             Build elyra/enterprise-gateway:dev docker image
 env                            Make a dev environment
 install                        Make a conda env with dist/*.whl and dist/*.tar.gz installed
 itest                          Run integration tests (optionally) against docker container
 kernelspecs                    Create an archive with sample kernelspecs
+kubernetes-enterprise-gateway  Build elyra/kubernetes-enterprise-gateway:dev docker image
+kubernetes-images              Build kubernetes docker images
+kubernetes-kernel-py           Build elyra/kubernetes-kernel-py:dev docker image
+kubernetes-kernel-r            Build elyra/kubernetes-kernel-r:dev docker image
+kubernetes-kernel-scala        Build elyra/kubernetes-kernel-scala:dev docker image
+kubernetes-kernel-tf-py        Build elyra/kubernetes-kernel-tf-py:dev docker image
+kubernetes-publish             Push kubernetes docker images to docker hub
+nb2kg                          Build elyra/nb2kg:dev docker image
 nuke                           Make clean + remove conda env
 release                        Make a wheel + source release on PyPI
 test                           Run unit tests
+yarn-spark                     Build elyra/yarn-spark:2.1.0 docker image
 ```
 Some of the more useful commands are listed below.
 
@@ -73,7 +86,7 @@ otherwise the command will use the default environment.
 Build a wheel file that can then be installed via `pip install`
 
 ```
-make dist
+make bdist
 ```
 
 ### Build the kernelspec tar file
@@ -87,8 +100,19 @@ target produces a tar file (`enterprise_gateway_kernelspecs.tar.gz`) in the `dis
 make kernelspecs
 ```
 
-Note: Because the scala launcher requires a jar file, `make kernelspecs` requires the use of `sbt` to build the scala launcher jar. Please consult the [sbt site](http://www.scala-sbt.org/) for directions to install/upgrade `sbt` on your platform. We currently prefer the use of 1.0.3.
+Note: Because the scala launcher requires a jar file, `make kernelspecs` requires the use of `sbt` to build the 
+scala launcher jar. Please consult the [sbt site](http://www.scala-sbt.org/) for directions to 
+install/upgrade `sbt` on your platform. We currently prefer the use of 1.0.3.
 
+
+### Build distribution files
+
+Builds the files necessary for a given release: the wheel file, the source tar file, and the kernelspecs tar
+file.  This is essentially a helper target consisting of the `bdist` `sdist` and `kernelspecs` targets.
+
+```
+make dist
+```
 
 ### Run the Enterprise Gateway server
 
@@ -118,9 +142,9 @@ make test
 
 ### Run the integration tests
 
-Run the integration tests suite. T
+Run the integration tests suite. 
 
-hese tests will bootstrap a docker image with Apache Spark using YARN resource manager and
+These tests will bootstrap a docker image with Apache Spark using YARN resource manager and
 Jupyter Enterprise Gateway and perform various tests for each kernel in both YARN client
 and YARN cluster mode.
 
@@ -130,8 +154,8 @@ make itest
 
 ### Build the docker images
 
-The following can be used to build all three docker images used within the project.  See 
-[docker images](docker.html) for specific details.
+The following can be used to build all docker images (including Kubernetes images) 
+used within the project.  See [docker images](docker.html) for specific details.
 
 ```
 make docker-images

--- a/docs/source/docker.md
+++ b/docs/source/docker.md
@@ -55,3 +55,34 @@ also sets some of the new variables that pertain to enterprise gateway (e.g., `K
 
 To build a local image, run `make docker-image-nb2kg`.  Because this is a development build, the 
 tag for this image will be `:dev`.
+
+## Kubernetes Images
+The following sections describe the docker images used within Kubernetes environments - all of which can be pulled from 
+the [Enterprise Gateway organization](https://hub.docker.com/r/elyra/) on dockerhub.
+
+### elyra/kubernetes-enterprise-gateway
+The primary image for Kubernetes support, [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/) 
+contains the Enterprise Gateway server software and default kernelspec files.  Its deployment is completely a function 
+of the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file
+
+We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container
+since we've found those to require post-deployment modifications from time to time.
+
+### elyra/kubernetes-kernel-py
+Image [elyra/kubernetes-kernel-py](https://hub.docker.com/r/elyra/kubernetes-kernel-py/) contains the IPython kernel.  It is currently built on the spark-on-kubernetes image 
+(`kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0`) and can be launched 
+as a spark application or in *vanilla* mode depending on its kernelspecs attributes.  We will likely introduce separate,
+non-spark, containers based on anaconda - so each kernelspec will likely be associated with different images.
+
+### elyra/kubernetes-kernel-tf-py
+Image [elyra/kubernetes-kernel-tf-py](https://hub.docker.com/r/elyra/kubernetes-kernel-tf-py/) is built on the Tensorflow image (`tensorflow/tensorflow:1.8.0-py3`) and is solely a *vanilla* kernel in the 
+sense that it does not support Spark context creation.  As noted in the image name, its language is Python and uses
+the IPython kernel within.
+
+### elyra/kubernetes-kernel-scala
+Image [elyra/kubernetes-kernel-scala](https://hub.docker.com/r/elyra/kubernetes-kernel-scala/) contains the Scala (Apache Toree) kernel and is currently build on the spark-on-kubernetes image (`kubespark/spark-driver:v2.2.0-kubernetes-0.5.0`).
+Since Toree is currently tied to Spark, creation of a *vanilla* mode Scala kernel is not high on our current set of priorities.
+
+### elyra/kubernetes-kernel-r
+Image [elyra/kubernetes-kernel-r](https://hub.docker.com/r/elyra/kubernetes-kernel-r/) contains the IRKernel and is currently built on the spark-on-kubernetes image (`kubespark/spark-driver-r:v2.2.0-kubernetes-0.5.0`).
+Like with `elyra/kubernetes-kernel-py` it can be launched in two modes depending on the need of a Spark context.

--- a/docs/source/getting-started-client-mode.md
+++ b/docs/source/getting-started-client-mode.md
@@ -1,4 +1,4 @@
-## Enabling Client Mode/Standalone Support
+## Enabling YARN Client Mode or Spark Standalone Support
 
 Jupyter Enterprise Gateway extends Jupyter Kernel Gateway and is 100% compatible with JKG, which means that by
 installing kernels in Enterprise Gateway and using the vanila kernelspecs created during installation you will
@@ -26,17 +26,17 @@ SPARK_HOME:/usr/hdp/current/spark2-client                            #For HDP di
 EG_REMOTE_HOSTS=elyra-node-1.fyre.ibm.com,elyra-node-2.fyre.ibm.com,elyra-node-3.fyre.ibm.com,elyra-node-4.fyre.ibm.com,elyra-node-5.fyre.ibm.com
 ```
 
-**Configuring Kernels for YARN Client mode**
+### Configuring Kernels for YARN Client mode
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
+[e.g. jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz).
 
-Considering we would like to enable the iPython Kernel that comes pre-installed with Anaconda to run on
+Considering we would like to enable the IPython Kernel that comes pre-installed with Anaconda to run on
 Yarn Client mode, we would have to copy the sample configuration folder **spark_python_yarn_client**
 to where the Jupyter kernels are installed (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "python3" | awk '{print $2}')"
 
@@ -75,7 +75,7 @@ After that, you should have a kernel.json that looks similar to the one below:
 After making any necessary adjustments such as updating SPARK_HOME or other environment specific configuration, you now should have 
 a new Kernel available which will use Jupyter Enterprise Gateway to execute your notebook cell contents.
 
-**Configuring Kernels for Spark Standalone mode**
+### Configuring Kernels for Spark Standalone mode
 
 The main difference between YARN Client and Standalone is the values used in SPARK_OPTS for the ```--master``` parameter.
 

--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -1,4 +1,4 @@
-## Enabling Cluster Mode Support
+## Enabling YARN Cluster Mode Support
 
 To leverage the full distributed capabilities of Jupyter Enterprise Gateway, there is a need to
 provide additional configuration options in a cluster deployment.
@@ -17,17 +17,17 @@ SPARK_HOME:/usr/hdp/current/spark2-client                            #For HDP di
 EG_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
 ``` 
 
-**Configuring Kernels for YARN Cluster mode**
+### Configuring Kernels for YARN Cluster mode
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release
-[e.g. jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6.0/jupyter_enterprise_gateway_kernelspecs-0.6.0.tar.gz).
+[e.g. jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz).
 
-Considering we would like to enable the iPython Kernel that comes pre-installed with Anaconda to run on Yarn Cluster mode, we
+Considering we would like to enable the IPython Kernel that comes pre-installed with Anaconda to run on Yarn Cluster mode, we
 would have to copy the sample configuration folder **spark_python_yarn_cluster** to where the Jupyter kernels are installed 
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.6/enterprise_gateway_kernelspecs.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "python3" | awk '{print $2}')"
 

--- a/docs/source/getting-started-conductor.md
+++ b/docs/source/getting-started-conductor.md
@@ -1,0 +1,5 @@
+## Enabling IBM Spectrum Conductor Support
+This information will be added shortly.  The configuration is similar to that of 
+[YARN Cluster mode](getting-started-cluster-mode.md) with the `ConductorClusterProcessProxy`
+used in place of `YARNClusterProcessProxy`.
+

--- a/docs/source/getting-started-kernels.md
+++ b/docs/source/getting-started-kernels.md
@@ -8,7 +8,7 @@ The following kernels have been tested with the Jupyter Enterprise Gateway:
 * R/Apache Spark 2.x with IRkernel
 
 We provide sample kernel configuration and launcher tar files as part of [each release](https://github.com/jupyter-incubator/enterprise_gateway/releases)
-(e.g. [jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz))
+(e.g. [jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz](https://github.com/jupyter-incubator/enterprise_gateway/releases/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz))
 that can be extracted and modified to fit your configuration.
 
 Please find below more details on specific kernels:
@@ -39,15 +39,15 @@ we would have to copy the sample configuration folder **spark_scala_yarn_client*
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
 
 cp $KERNELS_FOLDER/spark_scala/lib/*.jar  $KERNELS_FOLDER/spark_scala_yarn_cluster/lib
 ```
@@ -58,29 +58,29 @@ For more information about the Scala kernel, please visit the [Apache Toree](htt
 ### Installing support for Python (IPython kernel)
 
 The IPython kernel comes pre-installed with Anaconda and we have tested with its default version of 
-[iPython kernel](http://ipython.readthedocs.io/en/stable/).
+[IPython kernel](http://ipython.readthedocs.io/en/stable/).
 
 
-**Update the iPython Kernelspecs**
+**Update the IPython Kernelspecs**
 
-Considering we would like to enable the iPython kernel to run on YARN Cluster and Client mode
+Considering we would like to enable the IPython kernel to run on YARN Cluster and Client mode
 we would have to copy the sample configuration folder **spark_python_yarn_client** and
 **spark_python_yarn_client** to where the Jupyter kernels are installed
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 ```
 
-For more information about the iPython kernel, please visit the [iPython kernel](http://ipython.readthedocs.io/en/stable/) page.
+For more information about the IPython kernel, please visit the [IPython kernel](http://ipython.readthedocs.io/en/stable/) page.
 
 ### Installing support for R (IRkernel)
 
@@ -117,15 +117,15 @@ we would have to copy the sample configuration folder **spark_R_yarn_client** an
 (e.g. jupyter kernelspec list)
 
 ``` Bash
-wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.7.0/jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz
+wget https://github.com/jupyter-incubator/enterprise_gateway/releases/download/download/v0.9.1/jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz
 
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "spark_scala" | awk '{print $2}')"
 
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_cluster/ spark_R_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_cluster/ spark_R_yarn_cluster/
 
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.7.0.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-0.9.1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
 ```
 
 For more information about the iR kernel, please visit the [iR kernel](https://irkernel.github.io/) page.

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -1,4 +1,4 @@
-# Kubernetes Integration
+## Enabling Kubernetes Support
 This page describes the approach taken for integrating Enterprise Gateway into an existing
 Kubernetes cluster.
 
@@ -7,7 +7,12 @@ and exposed as a Kubernetes _service_.  In this way, Enterprise Gateway can leve
 balancing and high availability functionality provided by Kubernetes (although HA cannot be
 fully realized until EG supports persistent sessions).
 
-When residing in a [spark-on-kubernetes](https://github.com/apache-spark-on-k8s/spark) 
+As with all kubernetes deployments, Enterprise Gateway is built into a docker image.  The
+base Enterprise Gateway image is [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/) 
+and can be found in the Enterprise Gateway dockerhub organization [elyra](https://hub.docker.com/r/elyra/), along with
+other kubernetes-based images.  See [Kubernetes Images](docker.html#kubernetes-images) for image details.
+
+When deployed within a [spark-on-kubernetes](https://github.com/apache-spark-on-k8s/spark) 
 cluster, Enterprise Gateway can easily support cluster-managed kernels distributed across 
 the cluster. Enterprise Gateway will also provide standalone (i.e., _vanilla_) kernel 
 invocation (where spark contexts are not automatically created) which also benefits from 
@@ -16,15 +21,15 @@ their distribution across the cluster.
 ### Enterprise Gateway Deployment
 Enterprise Gateway manifests itself as a Kubernetes deployment, exposed externally by a 
 Kubernetes service.  It is identified by the name `enterprise-gateway` within the cluster. 
-In addition, all objects related to Enterprise Gateway have the kubernetes label of 
-`app=enterprise-gateway` applied.
+In addition, all objects related to Enterprise Gateway, including kernel instances, have 
+the kubernetes label of `app=enterprise-gateway` applied.
 
 The service is currently configured as type `NodePort` but is intended for type 
 `LoadBalancer` when appropriate network plugins are available.  Because kernels
 are stateful, the service is also configured with a `sessionAffinity` of `ClientIP`.  As
 a result, kernel creation requests will be routed to different deployment instances (see 
 deployment) thereby diminishing the need for a `LoadBalancer` type. Here's the service 
-yaml entry from `kubernetes-enterprise-gateway.yaml`:
+yaml entry from [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml):
 ```yaml
 apiVersion: v1
 kind: Service
@@ -45,8 +50,8 @@ spec:
 The deployment yaml essentially houses the pod description.  By increasing the number of `replicas`
 a configuration can experience instant benefits of distributing enterprise-gateway instances across 
 the cluster.  This implies that once session persistence is provided, we should be able to provide 
-highly available (HA) kernels.  Here's the yaml portion from `kubernetes-enterprise-gateway.yaml` 
-that defines the Kubernetes deployment (and pod):
+highly available (HA) kernels.  Here's the yaml portion from [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml)
+that defines the Kubernetes deployment and pod (some items may have changed):
 ```yaml
 apiVersion: apps/v1beta2
 kind: Deployment
@@ -76,6 +81,10 @@ spec:
           value: "600"
         - name: EG_LOG_LEVEL
           value: "DEBUG"
+        - name: EG_KERNEL_LAUNCH_TIMEOUT
+          value: "60"
+        - name: EG_KERNEL_WHITELIST
+          value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
         image: elyra/kubernetes-enterprise-gateway:dev
         name: enterprise-gateway
         args: ["--elyra"]
@@ -89,9 +98,9 @@ the kernels directory can be exposed as a
 _[Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes)_ thereby making 
 it available to all pods within the Kubernetes cluster.
 
-As an example, we have included stanza for creating a Persistent Volume (PV) and Persistent Volume 
-Claim (PVC), along with appropriate references to the PVC within each pod definition within  
-`kubernetes-enterprise-gateway.yaml`.  By default, these references are commented out as they require
+As an example, we have included a stanza for creating a Persistent Volume (PV) and Persistent Volume 
+Claim (PVC), along with appropriate references to the PVC within each pod definition within [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml).
+ By default, these references are commented out as they require
 the system administrator configure the appropriate PV type (e.g., nfs) and server IP.
 
 ```yaml
@@ -143,6 +152,10 @@ for the container specification and `volumes` in the pod specification):
           value: "600"
         - name: EG_LOG_LEVEL
           value: "DEBUG"
+        - name: EG_KERNEL_LAUNCH_TIMEOUT
+          value: "60"
+        - name: EG_KERNEL_WHITELIST
+          value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
         image: elyra/kubernetes-enterprise-gateway:dev
         name: enterprise-gateway
         args: ["--elyra"]
@@ -157,8 +170,9 @@ for the container specification and `volumes` in the pod specification):
         persistentVolumeClaim:
           claimName: kernelspecs-pvc
 ```
-Note that because the `kernel-pod.yaml` resides in the kernelspecs hierarchy, updates or 
-modifications to kubernetes kernel instances can also take place.
+Note that because the kernel pod definition file, [kernel-pod.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml), 
+resides in the kernelspecs hierarchy, updates or modifications to kubernetes kernel instances can now 
+also take place.  (We'll be looking at ways to make modifications to per-kernel configurations more manageable.)
 
 ### Kubernetes Kernel Instances
 There are essentially two kinds of kernels (independent of language) launched within an 
@@ -167,12 +181,12 @@ Enterprise Gateway Kubernetes cluster - _vanilla_ and _spark-on-kubernetes_ (if 
 When _vanilla_ kernels are launched, Enterprise Gateway is responsible for creating the 
 corresponding pod. On the other hand, _spark-on-kubernetes_ kernels are launched via 
 `spark-submit` with a specific `master` URI - which then creates the corresponding
-pod(s) (including executor pods).  Both launch mechanisms, however, use the same underlying 
-docker image for the pod.
+pod(s) (including executor pods).  Today, both launch mechanisms, however, use the same underlying 
+docker image for the pod (although that will likely change).
 
 Here's the yaml configuration used when _vanilla_ kernels are launched. As noted in the 
-`KubernetesProcessProxy` section below, this file (`kernel-pod.yaml`) serves as a template
-where each of the tags prefixed with `$` represent variables that are substituted at the 
+`KubernetesProcessProxy` section below, this file ([kernel-pod.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml))
+serves as a template where each of the tags prefixed with `$` represent variables that are substituted at the 
 time of the kernel's launch.
 ```yaml
 apiVersion: v1
@@ -193,8 +207,8 @@ spec:
       value: $connection_filename
     - name: KERNEL_LANGUAGE
       value: $language
-    - name: NO_SPARK_CONTEXT
-      value: $no_spark_context
+    - name: SPARK_CONTEXT_INITIALIZATION_MODE
+      value: $spark_context_initialization_mode
     image: $docker_image
     name: $kernel_username-$kernel_id
     command: ["/etc/bootstrap-kernel.sh"]
@@ -208,11 +222,14 @@ spec:
        claimName: kernelspecs-pvc
 ```
 There are a number of items worth noting:
-1. Each kernel pod can be identified in two ways using `kubectl`: 1) by the global label
-`app=enterprise-gateway` - useful when needing to identify all related objects (e.g., `kubectl get
-all -l app=enterprise-gateway`) and 2) by the kernel_id label `kernel_id=<kernel_id>` - useful
-when only needing specifics about a given kernel.  This label is used internally by enterprise-gateway 
-when performing its discovery and lifecycle management operations.
+1. Kernel pods can be identified in three ways using `kubectl`: 
+    1. By the global label `app=enterprise-gateway` - useful when needing to identify all related objects (e.g., `kubectl get
+all -l app=enterprise-gateway`) 
+    1. By the kernel_id label `kernel_id=<kernel_id>` - useful when only needing specifics about a given 
+    kernel.  This label is used internally by enterprise-gateway when performing its discovery and lifecycle management 
+    operations.
+    1. By the *component* label `component=kernel` - useful when needing to identity only kernels and not other enterprise-gateway
+    components.  (Note, the latter can be isolated via `component=enterprise-gateway`.)
 2. Each kernel pod is named by the invoking user (via the `KERNEL_USERNAME` env) and its 
 kernel_id (env `KERNEL_ID`).  This identifier also applies to those kernels launched 
 within `spark-on-kubernetes`.
@@ -227,61 +244,72 @@ will contain the `mountPath` and PVC name.
 ### KubernetesProcessProxy
 To indicate that a given kernel should be launched into a Kubernetes configuration, the
 kernel.json file must include a `process_proxy` stanza indicating a `class_name:`  of 
-`KubernetesProcessProxy`. This ensures the appropriate lifecycle management will take place.
+`KubernetesProcessProxy`. This ensures the appropriate lifecycle management will take place relative
+to a Kubernetes environment.
 
 Along with the `class_name:` entry, this process proxy stanza should also include a proxy 
 configuration stanza  which specifies the docker image to associate with the kernel's
 pod.  If this entry is not provided, the Enterprise Gateway implementation will use a default 
-entry of `elyra/kubernetes-kernel:dev`.  In either case, this value is made available to the 
+entry of `elyra/kubernetes-kernel-py:dev`.  In either case, this value is made available to the 
 rest of the parameters used to launch the kernel by way of an environment variable: 
 `EG_KUBERNETES_KERNEL_IMAGE`.
 
 ```json
+{
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
     "config": {
-      "image_name": "elyra/kubernetes-kernel:dev"
+      "image_name": "elyra/kubernetes-kernel-py:dev"
     }
+  }
+}
 ```
 As always, kernels are launched by virtue of the `argv:` stanza in their respective kernel.json
 files.  However, when launching _vanilla_ kernels in a kubernetes environment, what gets
 invoked isn't the kernel's launcher, but, instead, a python script that is responsible
 for using the [Kubernetes Python API](https://github.com/kubernetes-client/python) to 
 create the corresponding pod instance.  The pod is _configured_ by applying the values 
-to each of the substitution parameters into the `kernel-pod.yaml` file previously displayed. 
+to each of the substitution parameters into the [kernel-pod.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml) file previously displayed. 
 This file resides in the same `scripts` directory as the kubernetes launch script - 
 `launch_kubernetes.py` - which is referenced by the kernel.json's `argv:` stanza:
 ```json
+{
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_kubernetes.py",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
-    "--RemoteProcessProxy.no-spark-context"
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
   ]
+}
 ```
-By default, _vanilla_ kernels use a flag to indicate no spark context will automatically be 
-created (`--RemoteProcessProxy.no-spark-context`).
+By default, _vanilla_ kernels use a value of `none` for the spark context initialization mode so
+no context will be created automatically.
 
 When the kernel is intended to target _Spark-on-kubernetes_, its launch is
 very much like kernels launched in YARN _cluster mode_, albeit with a completely different
 set of parameters.  Here's an example `SPARK_OPTS` string value which best conveys the idea:
-```json
+```
     "SPARK_OPTS": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=kubespark/spark-executor-py:v2.2.0-kubernetes-0.5.0 --conf spark.kubernetes.submission.waitAppCompletion=false",
 ```
 Note that each of the labels previously discussed are also applied to the _driver_ and _executor_ pods.
 
 For these invocations, the `argv:` is nearly identical to non-kubernetes configurations, invoking
-a `run.sh` script which essentially holds the `spark-submit` invocation which takes the aforementioned
+a `run.sh` script which essentially holds the `spark-submit` invocation that takes the aforementioned
 `SPARK_OPTS` as its primary parameter:
 ```json
+{
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_python_kubernetes/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
+}
 ```
 
 ### Deploying Enterprise Gateway on Kubernetes
@@ -290,19 +318,29 @@ on the master node, pull the Enterprise Gateway and Kernel images on each worker
 
 ```
 docker pull elyra/kubernetes-enterprise-gateway:dev
-docker pull elyra/kubernetes-kernel:dev
+docker pull elyra/kubernetes-kernel-py:dev
 ```
+
+**Note:** It is important to pre-seed the worker nodes with **all** kernel images, otherwise the automatic download 
+time will count against the kernel's launch timeout.  Although this will likely only impact the first launch of a given 
+kernel on a given work node, when multiplied against the number of kernels and worker nodes, it will prove to be a 
+frustrating user experience. 
+
+If it is not possible to pre-seed the nodes, you will likely need to adjust the `EG_KERNEL_LAUNCH_TIMEOUT` value 
+in the `kubernetes-enterprise-gateway.yaml` file as well as the `KG_REQUEST_TIMEOUT` parameter that issue the kernel 
+start requests from the `NB2KG` extension of the Notebook client.
+
 ##### Create the Enterprise Gateway kubernetes service and deployment
 From the master node, create the service and deployment using the yaml file from the git
 repository:
 
 ```
-kubectl create -f etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml
+kubectl apply -f etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml
 
 service "enterprise-gateway" created
 deployment "enterprise-gateway" created
 ```
-##### Confirm deployment and note service port mapping
+##### Confirm deployment and note the service port mapping
 ```
 kubectl get all -l app=enterprise-gateway
 
@@ -325,81 +363,24 @@ the cluster-ip entry (e.g.,`10.110.253.220`).
 (Note: if the number of replicas is > 1, then you will see two pods listed with different
 five-character suffixes.)
 
-##### Confirm proper startup of enterprise gateway via k8s logs
-```
-kubectl logs -f deploy/enterprise-gateway
-
-Starting Jupyter Enterprise Gateway...
-[D 2018-01-30 19:26:20.588 EnterpriseGatewayApp] Searching [u'/usr/local/share/jupyter', '/root/.jupyter', '/usr/etc/jupyter', '/usr/local/etc/jupyter', '/etc/jupyter'] for config files
-[D 2018-01-30 19:26:20.588 EnterpriseGatewayApp] Looking for jupyter_config in /etc/jupyter
-[D 2018-01-30 19:26:20.588 EnterpriseGatewayApp] Looking for jupyter_config in /usr/local/etc/jupyter
-[D 2018-01-30 19:26:20.589 EnterpriseGatewayApp] Looking for jupyter_config in /usr/etc/jupyter
-[D 2018-01-30 19:26:20.589 EnterpriseGatewayApp] Looking for jupyter_config in /root/.jupyter
-[D 2018-01-30 19:26:20.589 EnterpriseGatewayApp] Looking for jupyter_config in /usr/local/share/jupyter
-[D 2018-01-30 19:26:20.590 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /etc/jupyter
-[D 2018-01-30 19:26:20.590 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /usr/local/etc/jupyter
-[D 2018-01-30 19:26:20.590 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /usr/etc/jupyter
-[D 2018-01-30 19:26:20.590 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /root/.jupyter
-[D 2018-01-30 19:26:20.591 EnterpriseGatewayApp] Looking for jupyter_enterprise_gateway_config in /usr/local/share/jupyter
-[I 2018-01-30 19:26:20.602 EnterpriseGatewayApp] Jupyter Enterprise Gateway at http://0.0.0.0:8888
-```
-(Note, if the number of replicas is > 1, then you will see an indication in the first line of 
-output as to which pod this logs command is tailing.  Specific pods can be logged using:
-`kubectl logs -f po/<pod>` (e.g., `kubectl logs -f po/enterprise-gateway-74c46cb7fc-jrkl7`)).
-
-##### On the client, startup Notebook with NB2KG.  
-I use a script named `docker_jnb` which essentially invokes `docker run`.  Make sure the port 
-for the gateway host is the same port number referenced in the service port mapping 
-(e.g., `32422`), or, if on the same host, use the cluster-ip and port `8888` (e.g., 
-`10.110.253.220:8888`) instead of the DNS name.
-```
-docker_jnb -u alice -l 9001 -n ~/notebooks/elyra --name alice-kube elyra-kube1.foo.bar.com:32422 > ~/logs/9001.out 2>&1 &
+**Tip:** You can avoid the need to point at a different port each time EG is launched by adding an
+`externalIPs:` entry to the `spec:` section of the `kubernetes-enterprise-gateway.yaml` file.  The
+file is delivered with this entry commented out.  Of course, you'll need to change the IP address
+to that of your kubernetes master node once the comments characters have been removed.
+```text
+# Uncomment in order to use <k8s-master>:8888
+#  externalIPs:
+#  - 9.30.118.200
 ```
 
-Capture the token from the log (9001.out).  This also shows the complete `docker run` command.
-```
-docker run -t --rm -e LOG_LEVEL=INFO -e KERNEL_USERNAME=alice -e KG_HTTP_USER=alice -e KG_HTTP_PASS=guest-password  -e KG_URL=http://elyra-kube1.foo.bar.com:32422 --name alice-kube -p 9001:8888 -v /Users/kbates/notebooks/elyra:/tmp/notebooks -w /tmp/notebooks elyra/nb2kg:dev 
-Starting nb2kg against gateway:  http://elyra-kube1.foo.bar.com:32422
-Nootbook port:  8888
-Kernel user:  alice
-[I 19:27:23.045 NotebookApp] Writing notebook server cookie secret to /home/jovyan/.local/share/jupyter/runtime/notebook_cookie_secret
-[I 19:27:23.343 NotebookApp] JupyterLab alpha preview extension loaded from /opt/conda/lib/python3.6/site-packages/jupyterlab
-[I 19:27:23.345 NotebookApp] Loaded nb2kg extension
-[I 19:27:23.345 NotebookApp] Overriding handler URLSpec('/api/kernelspecs/(?P<kernel_name>[\\w\\.\\-%]+)$', <class 'nb2kg.handlers.KernelSpecHandler'>, kwargs=None, name=None)
-[I 19:27:23.345 NotebookApp] Overriding handler URLSpec('/api/kernelspecs$', <class 'nb2kg.handlers.MainKernelSpecHandler'>, kwargs=None, name=None)
-[I 19:27:23.345 NotebookApp] Overriding handler URLSpec('/api/kernels/(?P<kernel_id>\\w+-\\w+-\\w+-\\w+-\\w+)/channels$', <class 'nb2kg.handlers.WebSocketChannelsHandler'>, kwargs=None, name=None)
-[I 19:27:23.346 NotebookApp] Overriding handler URLSpec('/api/kernels/(?P<kernel_id>\\w+-\\w+-\\w+-\\w+-\\w+)/(?P<action>restart|interrupt)$', <class 'nb2kg.handlers.KernelActionHandler'>, kwargs=None, name=None)
-[I 19:27:23.346 NotebookApp] Overriding handler URLSpec('/api/kernels/(?P<kernel_id>\\w+-\\w+-\\w+-\\w+-\\w+)$', <class 'nb2kg.handlers.KernelHandler'>, kwargs=None, name=None)
-[I 19:27:23.346 NotebookApp] Overriding handler URLSpec('/api/kernels$', <class 'nb2kg.handlers.MainKernelHandler'>, kwargs=None, name=None)
-[I 19:27:23.349 NotebookApp] Serving notebooks from local directory: /tmp/notebooks
-[I 19:27:23.349 NotebookApp] 0 active kernels
-[I 19:27:23.349 NotebookApp] The Jupyter Notebook is running at:
-[I 19:27:23.349 NotebookApp] http://0.0.0.0:8888/?token=bbc11af31786bd9b313ae1c330d53c9b944f596c4b6f3e95
-[I 19:27:23.349 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
-[C 19:27:23.349 NotebookApp] 
-    
-    Copy/paste this URL into your browser when you connect for the first time,
-    to login with a token:
-        http://0.0.0.0:8888/?token=bbc11af31786bd9b313ae1c330d53c9b944f596c4b6f3e95
-```
+The value of the `KG_URL` used by `NB2KG` will vary depending on whether you choose to define an external IP
+or not.  If and external IP is defined, you'll set `KG_URL=<externalIP>:8888` else you'll set `KG_URL=<k8s-master>:32422`
+**but also need to restart clients each time Enterprise Gateway is started.**  As a result, use of the `externalIPs:` value
+is highly recommended.
 
-Once the token is entered into the browser prompt, you should see a list of kernels reflected 
-in the enterprise gateway log.  If using more than one replica and you don't see this additional
-output, check the log of the othe replica pod.
-```
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel python_kubernetes in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_python_kubernetes in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_r_yarn_client in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_python_yarn_cluster in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_python_yarn_client in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_r_yarn_cluster in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_scala_yarn_cluster in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel spark_scala_yarn_client in /usr/local/share/jupyter/kernels
-[D 2018-01-30 19:27:37.852 EnterpriseGatewayApp] Found kernel python2 in /usr/share/jupyter/kernels
-```
-Open or create notebooks with either `python_kubernetes` or `spark_python_kubernetes` - both should be usable.
 
-### Troubleshooting Tips
+### Kubernetes Tips
+The following items illustrate some useful commands for navigating Enterprise Gateway within a kubernetes envrionment.
 
 - All objects created on behalf of enterprise gateway can be located using the label `app=enterprise-gateway`.  You'll
 probably see duplicated entries for the deployments(deploy) and replication sets (rs) - I didn't include the
@@ -418,7 +399,7 @@ po/alice-5e755458-a114-4215-96b7-bcb016fc7b62   1/1       Running   0          8
 po/enterprise-gateway-74c46cb7fc-jrkl7          1/1       Running   0          3h
 
 ```
-- All objects related to kernels can be located using the label `kernel_id=<kernel_id>`
+- All objects related to a given kernel can be located using the label `kernel_id=<kernel_id>`
 ```
 kubectl get all -l kernel_id=5e755458-a114-4215-96b7-bcb016fc7b62
 
@@ -426,12 +407,15 @@ NAME                                            READY     STATUS    RESTARTS   A
 po/alice-5e755458-a114-4215-96b7-bcb016fc7b62   1/1       Running   0          28s
 ```
 
-- To terminate all enterprise-gateway objects, use the same label `app=enterprise-gateway`
+- To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
 ```
 kubectl delete all -l app=enterprise-gateway
 ```
+Note that this should not imply that kernels be "shutdown" using a the `kernel_id=` label.  This will likely trigger
+Jupyter's auto-restart logic.
 
-- To enter into a given pod (i.e., container), use the exec command with the pod name
+- To enter into a given pod (i.e., container) in order to get a better idea of what might be happening within the
+container, use the exec command with the pod name
 ```
 kubectl exec -it enterprise-gateway-74c46cb7fc-jrkl7 /bin/bash
 ```
@@ -440,6 +424,7 @@ kubectl exec -it enterprise-gateway-74c46cb7fc-jrkl7 /bin/bash
 ```
 kubectl logs -f po/alice-5e755458-a114-4215-96b7-bcb016fc7b62
 ```
+Note that if using multiple replicas, commands against each pod are required.
 
 - The Kubernetes dashboard is useful as well.  Its located at port `30000` of the master node
 ```
@@ -451,26 +436,7 @@ the far right.
 - User \"system:serviceaccount:default:default\" cannot list pods in the namespace \"default\"
 
 On a recent deployment, Enterprise Gateway was not able to create or list kernel pods.  Found
-the following command was necessary.  (Need to revisit security setup.)
+the following command was necessary.  (Kubernetes security relative to Enterprise Gateway is still under construction.)
 ```bash
 kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin  --serviceaccount=default:default
 ```
-
-
-### Spark-on-Kubernetes Setup (internal)
-Here are some instructions for setting up Kubernetes on a Fyre cluster.  It leverages scripts
-provided by STC-East and should be considered internal information.
-
-- Provision a fyre cluster (e.g., `elyra-kube{1,2,3}.fyre.ibm.com`). I would try to keep the 
-nodes limited to two or three.
-
-- Install Spark-on-Kubernetes.  Follow the first three steps from the 
-[kube-setup](https://github.ibm.com/stc-east/kube-setup) repo, 
-taking the `spark-on-kubernetes` option on step 3.
-
-- If you don't have `elyra/kubernetes-enterprise-gateway:dev` or `elyra/kubernetes-kernel:dev` images, they
-can be pulled from [docker hub](https://hub.docker.com/u/elyra/dashboard/) or build via 
-`make clean bdist kernelspecs docker-images-kubernetes`. 
-
-- Either copy the `etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml`
-to a local directory or clone the repo `git clone git@github.com:SparkTC/enterprise_gateway.git`.

--- a/docs/source/getting-started-other-features.md
+++ b/docs/source/getting-started-other-features.md
@@ -1,5 +1,5 @@
-## Advanced Features
-
+## Ancillary Features
+This page points out some features and functionality worthy of your attention but necessarily part of the Jupyter Enterprise Gateway implementation.
 
 ### Culling idle kernels
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -8,6 +8,8 @@ The following Resource Managers are supported with the Jupyter Enterprise Gatewa
 * Spark Standalone
 * YARN Resource Manager - Client Mode
 * YARN Resource Manager - Cluster Mode
+* IBM Spectrum Conductor - Cluster Mode
+* Kubernetes
 
 The following kernels have been tested with the Jupyter Enterprise Gateway:
 
@@ -52,7 +54,7 @@ latest Python version (currently Python 2.7 and Python 3.6).
 * Install the version of Anaconda which you downloaded, following the instructions on the download
 page.
 
-* Install the latest version of Jupyter Enterprise Gateway from [PyPI](https://pypi.python.org/pypi/jupyter_enterprise_gateway/0.6.0)
+* Install the latest version of Jupyter Enterprise Gateway from [PyPI](https://pypi.python.org/pypi/jupyter_enterprise_gateway/0.9.1)
 using `pip`(part of Anaconda) along with its dependencies.
 
 ```bash
@@ -86,17 +88,20 @@ kernels with Jupyter Enterprise Gateway:
 
 * [Installing and Configuring kernels](getting-started-kernels.md)
 
-### Configuring Spark Resource Managers
+### Configuring Resource Managers
 
 To leverage the full distributed capabilities of Spark, Jupyter Enterprise Gateway has provided
-deep integrarion with YARN resource manager. Having said that, EG also supports running in 
-pseudo-distributed utilizing both YARN client or Spark Standalone modes. 
+deep integrarion with the Apache Hadoop YARN resource manager. Having said that, Enterprise Gateway 
+also supports running in a pseudo-distributed utilizing both YARN client or Spark Standalone modes. 
+We've also recently added  Kubernetes and IBM Spectrum Conductor integrations. 
 
-Please follow the links below to learn more specific details about how to enable/configure
-the different modes: 
+Please follow the links below to learn specific details about how to enable/configure
+the different modes of distributing your kernels: 
 
-* [Enabling Cluster Mode support](getting-started-cluster-mode.md)
-* [Enabling Client Mode/Standalone support](getting-started-client-mode.md)
+* [Enabling YARN Cluster Mode support](getting-started-cluster-mode.html)
+* [Enabling YARN Client Mode or Spark Standalone support](getting-started-client-mode.html)
+* [Enabling Kubernetes Support](getting-started-kubernetes.html)
+* [Enabling IBM Spectrum Conductor Support](getting-started-conductor.html)
 
 ### Starting Enterprise Gateway
 Very few arguments are necessary to minimally start Enterprise Gateway.  The following command 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,9 +20,11 @@ the number of active kernels can be dramatically increased.
    getting-started
    getting-started-cluster-mode
    getting-started-client-mode
-   getting-started-advanced-features
+   getting-started-kubernetes
+   getting-started-conductor
    getting-started-kernels
    getting-started-security
+   getting-started-other-features
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -9,10 +9,9 @@ We have plenty to do, now and in the future.  Here's where we're headed:
   * Lifecycle management
   * Time running, stop/kill, Profile Management, etc
 * Support for other resource managers
-  * Kubernetes
-  * Platform Conductor
 * User Environments
 * High Availability
+  * Session persistence
 * Batch REST API
 
 We'd love to hear any other use cases you might have and look forward to your contributions to Jupyter Enterprise Gateway.

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -1,4 +1,6 @@
 ## Troubleshooting
+This page identifies scenarios we've encountered when running Enterprise Gateway.  We also provide 
+instructions for setting up a debug environment on our [Debugging Jupyter Enterprise Gateway](debug.html) page.
 
 - **I'm trying to launch a (Python/Scala/R) kernel in YARN Cluster Mode but it failed with 
 a "Kernel error" and State: 'FAILED'.**

--- a/etc/docker/kubernetes-enterprise-gateway/README.md
+++ b/etc/docker/kubernetes-enterprise-gateway/README.md
@@ -1,0 +1,14 @@
+This image adds support for [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster.  It is currently built on [kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0]() deriving from the [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/spark) fork.
+
+# What it Gives You
+* [Jupyter Enterprise Gateway](https://github.com/jupyter-incubator/enterprise_gateway)
+* Python/R/Toree kernels that can be launched and distributed across a Kubernetes cluster.
+
+# Basic Use
+Pull this image, along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
+
+Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+
+For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kubernetes-kernel-py/README.md
+++ b/etc/docker/kubernetes-kernel-py/README.md
@@ -1,0 +1,16 @@
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster.  It is currently built on [kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0](https://hub.docker.com/r/kubespark/spark-driver-py/) deriving from the [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/spark) fork.
+
+# What it Gives You
+* IPython kernel support 
+* Spark on kubernetes support from within a Jupyter Notebook
+
+# Basic Use
+Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
+
+Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+
+Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against  the Enterprise Gateway instance and pick either of the python-related kernels.
+
+For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kubernetes-kernel-r/README.md
+++ b/etc/docker/kubernetes-kernel-r/README.md
@@ -1,0 +1,16 @@
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster.  It is currently built on [kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0]() deriving from the [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/spark) fork.
+
+# What it Gives You
+* IPython kernel support 
+* Spark on kubernetes support from within a Jupyter Notebook
+
+# Basic Use
+Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
+
+Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+
+Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against the Enterprise Gateway instance and pick either of the python-related kernels.
+
+For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kubernetes-kernel-scala/README.md
+++ b/etc/docker/kubernetes-kernel-scala/README.md
@@ -1,0 +1,17 @@
+This image enables the use of a Scala ([Apache Toree](http://toree.apache.org/)) kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster.  It is currently built on [kubespark/spark-driver:v2.2.0-kubernetes-0.5.0](https://hub.docker.com/r/kubespark/spark-driver-py/) deriving from the [apache-spark-on-k8s](https://github.com/apache-spark-on-k8s/spark) fork.
+
+# What it Gives You
+* Scala (Toree) kernel support 
+* Spark on kubernetes support from within a Jupyter Notebook
+
+# Basic Use
+Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and
+image downloads can seriously undermine that window.
+
+Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+
+Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against the Enterprise Gateway instance and pick either of the scala-related kernels.
+
+For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kubernetes-kernel-tf-py/README.md
+++ b/etc/docker/kubernetes-kernel-tf-py/README.md
@@ -1,0 +1,15 @@
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster that can perform Tensorflow operations.  It is currently built on [tensorflow/tensorflow:1.8.0-py3](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/README.md) project.
+
+# What it Gives You
+* IPython kernel support supplemented with Tensorflow functionality
+
+# Basic Use
+Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
+
+Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+
+Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against  the Enterprise Gateway instance and pick either of the python-related kernels.
+
+For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).


### PR DESCRIPTION
Updated the online documentation to include the necessary information
for Kubernetes support.  This consisted of extending our set of process
proxy implementations and adding descriptions for the various images.

I also updated the elyra dockerhub kubernetes images with the contents
of their respective README.md files (added in this change).

A general walk through of the entire online documentation set was performed
and I updated the version-specific references to the latest, although
that isn't always necessary.  I felt like we should be more recent that
0.6.0 though.

I added a placeholder for the IBM Spectrum Conductor process proxy since
it was odd not have anything there at this point.  That can be filled in
later.  Hoping @charlieeeeeee can take a crack at that.

Fixes #365