### PR TITLE
Update kubernetes kernelspecs and launchers with initialization mode

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -835,9 +835,8 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
             error_http_code = 500
             reason = "Waited too long ({}s) to get connection file".format(self.kernel_launch_timeout)
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
-            self.log.error(timeout_message)
             self.kill()
-            raise tornado.web.HTTPError(error_http_code, timeout_message)
+            self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 
     def cleanup(self):
         self.assigned_ip = None

--- a/etc/docker/kubernetes-enterprise-gateway/Dockerfile
+++ b/etc/docker/kubernetes-enterprise-gateway/Dockerfile
@@ -1,6 +1,6 @@
 FROM kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0
 
-RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev
+RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev curl
 
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp
@@ -8,6 +8,15 @@ RUN pip install cffi kubernetes send2trash /tmp/jupyter_enterprise_gateway*.whl 
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+
+# Install Toree for both vanilla and cluster - although these are not used except for runtime discovery.
+RUN cd /tmp && \
+	curl -O https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc5/toree-pip/toree-0.2.0.tar.gz && \
+	tar xf toree-0.2.0.tar.gz && \
+	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/scala_kubernetes/lib && \
+	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/spark_scala_kubernetes/lib && \
+	rm -rf toree-0.2.0*
+
 COPY start-enterprise-gateway.sh.template /usr/local/share/jupyter
 COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh
 

--- a/etc/docker/kubernetes-kernel-py/bootstrap-kernel.sh
+++ b/etc/docker/kubernetes-kernel-py/bootstrap-kernel.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, no-spark-context-opt=${KERNEL_NO_SPARK_CONTEXT_OPT}
+echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, spark-context-init-mode=${KERNEL_SPARK_CONTEXT_INIT_MODE}
 
 if [[ "${KERNEL_LANGUAGE}" == "python" ]];
 then
-	echo "python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}"
-	python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}
+	echo "python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+	python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
 else
 	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
 	exit 1

--- a/etc/docker/kubernetes-kernel-r/bootstrap-kernel.sh
+++ b/etc/docker/kubernetes-kernel-r/bootstrap-kernel.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, no-spark-context-opt=${KERNEL_NO_SPARK_CONTEXT_OPT}
+echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, spark-context-init-mode=${KERNEL_SPARK_CONTEXT_INIT_MODE}
 
 if [[ "${KERNEL_LANGUAGE}" == "r" ]];
 then
-	echo "Rscript /usr/local/share/jupyter/kernels/R_kubernetes/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}"
-	Rscript /usr/local/share/jupyter/kernels/R_kubernetes/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}
+	echo "Rscript /usr/local/share/jupyter/kernels/R_kubernetes/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+	Rscript /usr/local/share/jupyter/kernels/R_kubernetes/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
 else
 	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
 	exit 1

--- a/etc/docker/kubernetes-kernel-scala/Dockerfile
+++ b/etc/docker/kubernetes-kernel-scala/Dockerfile
@@ -5,7 +5,7 @@ ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 # Install Toree for both vanilla and cluster
 RUN cd /tmp && \
     apk --no-cache add curl && \
-	curl -O https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc3/toree-pip/toree-0.2.0.tar.gz && \
+	curl -O https://dist.apache.org/repos/dist/dev/incubator/toree/0.2.0-incubating-rc5/toree-pip/toree-0.2.0.tar.gz && \
 	tar xf toree-0.2.0.tar.gz && \
 	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/scala_kubernetes/lib && \
 	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/spark_scala_kubernetes/lib && \

--- a/etc/docker/kubernetes-kernel-scala/bootstrap-kernel.sh
+++ b/etc/docker/kubernetes-kernel-scala/bootstrap-kernel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, no-spark-context-opt=${KERNEL_NO_SPARK_CONTEXT_OPT}
+echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, spark-context-init-mode=${KERNEL_SPARK_CONTEXT_INIT_MODE}
 
 if [[ "${KERNEL_LANGUAGE}" != "scala" ]];
 then
@@ -11,12 +11,20 @@ fi
 PROG_HOME=/usr/local/share/jupyter/kernels/scala_kubernetes
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+if [ ! -f ${TOREE_ASSEMBLY} ]; then
+    echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 # Toree launcher jar path, plus required lib jars (toree-assembly)
 JARS="${TOREE_ASSEMBLY}"
 # Toree launcher app path
 LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
 LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+if [ ! -f ${LAUNCHER_APP} ]; then
+    echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 SPARK_OPTS="--name ${KERNEL_USERNAME}-${KERNEL_ID}"
 TOREE_OPTS="--alternate-sigint USR2"
@@ -29,7 +37,7 @@ eval exec \
      --class launcher.ToreeLauncher \
      "${LAUNCHER_APP}" \
      "${TOREE_OPTS}" \
-     "--profile ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}"
+     "--profile ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
 set +x
 
 exit 0

--- a/etc/docker/kubernetes-kernel-tf-py/bootstrap-kernel.sh
+++ b/etc/docker/kubernetes-kernel-tf-py/bootstrap-kernel.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, no-spark-context-opt=${KERNEL_NO_SPARK_CONTEXT_OPT}
+echo kernel-bootstrap.sh: language=${KERNEL_LANGUAGE}, connection-file=${KERNEL_CONNECTION_FILENAME}, reponse-addr=${EG_RESPONSE_ADDRESS}, spark-context-init-mode=${KERNEL_SPARK_CONTEXT_INIT_MODE}
 
 if [[ "${KERNEL_LANGUAGE}" == "python" ]];
 then
-	echo "python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}"
-	python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} ${KERNEL_NO_SPARK_CONTEXT_OPT}
+	echo "python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+	python /usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
 else
 	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
 	exit 1

--- a/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
+++ b/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
@@ -23,8 +23,8 @@ spec:
       value: $connection_filename
     - name: KERNEL_LANGUAGE
       value: $language
-    - name: KERNEL_NO_SPARK_CONTEXT_OPT
-      value: $no_spark_context_opt
+    - name: KERNEL_SPARK_CONTEXT_INIT_MODE
+      value: $spark_context_init_mode
     - name: KERNEL_USERNAME
       value: $kernel_username
     - name: KERNEL_ID

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -8,7 +8,7 @@ import urllib3
 urllib3.disable_warnings()
 
 
-def launch_kubernetes_kernel(connection_file, response_addr, no_spark_context):
+def launch_kubernetes_kernel(connection_file, response_addr, spark_context_init_mode):
     # Launches a containerized kernel as a kubernetes pod.
 
     config.load_incluster_config()
@@ -21,7 +21,7 @@ def launch_kubernetes_kernel(connection_file, response_addr, no_spark_context):
     keywords['docker_image'] = os.environ.get('EG_KUBERNETES_KERNEL_IMAGE')
     keywords['response_address'] = response_addr
     keywords['connection_filename'] = connection_file
-    keywords['no_spark_context_opt'] = "--RemoteProcessProxy.no-spark-context" if no_spark_context else ""
+    keywords['spark_context_init_mode'] = spark_context_init_mode
 
     with open(os.path.join(os.path.dirname(__file__), "kernel-pod.yaml")) as f:
         yaml_template = f.read()
@@ -32,20 +32,20 @@ def launch_kubernetes_kernel(connection_file, response_addr, no_spark_context):
 if __name__ == '__main__':
     """
         Usage: launch_kubernetes_kernel [connection_file] [--RemoteProcessProxy.response-address <response_addr>]
-                    [--RemoteProcessProxy.no-spark-context]
+                    [--RemoteProcessProxy.spark-context-initialization-mode <mode>]
     """
 
     parser = argparse.ArgumentParser()
     parser.add_argument('connection_file', help='Connection file to write connection info')
     parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
                         metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
-    parser.add_argument('--RemoteProcessProxy.no-spark-context', dest='no_spark_context',
-                        action='store_true', help='Indicates that no spark context should be created',
-                        default=False)
+    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
+                        help='Indicates whether or how a spark context should be created',
+                        default='lazy')
 
     arguments = vars(parser.parse_args())
     connection_file = arguments['connection_file']
     response_addr = arguments['response_address']
-    no_spark_context = arguments['no_spark_context']
+    spark_context_init_mode = arguments['spark_context_init_mode']
 
-    launch_kubernetes_kernel(connection_file, response_addr, no_spark_context)
+    launch_kubernetes_kernel(connection_file, response_addr, spark_context_init_mode)

--- a/etc/kernelspecs/R_kubernetes/kernel.json
+++ b/etc/kernelspecs/R_kubernetes/kernel.json
@@ -15,6 +15,7 @@
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
-    "--RemoteProcessProxy.no-spark-context"
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
   ]
 }

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -15,6 +15,7 @@
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
-    "--RemoteProcessProxy.no-spark-context"
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
   ]
 }

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -15,6 +15,7 @@
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
-    "--RemoteProcessProxy.no-spark-context"
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
   ]
 }

--- a/etc/kernelspecs/scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/scala_kubernetes/kernel.json
@@ -15,6 +15,7 @@
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
-    "--RemoteProcessProxy.no-spark-context"
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
   ]
 }

--- a/etc/kernelspecs/spark_R_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_R_kubernetes/kernel.json
@@ -10,13 +10,15 @@
   },
   "env": {
     "SPARK_HOME": "/opt/spark",
-    "SPARK_OPTS": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
+    "SPARK_OPTS": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.label.component=kernel --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.component=kernel --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_R_kubernetes/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_python_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_python_kubernetes/kernel.json
@@ -10,13 +10,15 @@
   },
   "env": {
     "SPARK_HOME": "/opt/spark",
-    "SPARK_OPTS": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
+    "SPARK_OPTS": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.label.component=kernel --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.component=kernel --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_python_kubernetes/bin/run.sh",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "lazy"
   ]
 }

--- a/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
@@ -24,7 +24,11 @@ fi
 
 PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
-TOREE_ASSEMBLY="local://${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+if [ ! -f ${TOREE_ASSEMBLY} ]; then
+    echo "Toree assembly '${PROG_HOME}/lib/toree-assembly-*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 # The SPARK_OPTS values during installation are stored in __TOREE_SPARK_OPTS__. This allows values to be specified during
 # install, but also during runtime. The runtime options take precedence over the install options.
@@ -37,10 +41,14 @@ if [ "${TOREE_OPTS}" = "" ]; then
 fi
 
 # Toree launcher jar path, plus required lib jars (toree-assembly)
-JARS="${TOREE_ASSEMBLY}"
+JARS="local://${TOREE_ASSEMBLY}"
 # Toree launcher app path
 LAUNCHER_JAR=`(cd "${PROG_HOME}/lib"; ls -1 toree-launcher*.jar;)`
-LAUNCHER_APP="local://${PROG_HOME}/lib/${LAUNCHER_JAR}"
+LAUNCHER_APP="${PROG_HOME}/lib/${LAUNCHER_JAR}"
+if [ ! -f ${LAUNCHER_APP} ]; then
+    echo "Scala launcher jar '${PROG_HOME}/lib/toree-launcher*.jar' is missing.  Exiting..."
+    exit 1
+fi
 
 set -x
 eval exec "${IMPERSONATION_OPTS}" \
@@ -48,7 +56,7 @@ eval exec "${IMPERSONATION_OPTS}" \
      "${SPARK_OPTS}" \
      --jars "${JARS}" \
      --class launcher.ToreeLauncher \
-     "${LAUNCHER_APP}" \
+     "local://${LAUNCHER_APP}" \
      "${TOREE_OPTS}" \
      "${LAUNCH_OPTS}" \
      "$@"

--- a/etc/kernelspecs/spark_scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_scala_kubernetes/kernel.json
@@ -10,7 +10,7 @@
   },
   "env": {
     "SPARK_HOME": "/opt/spark",
-    "__TOREE_SPARK_OPTS__": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --driver-memory 2G --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
+    "__TOREE_SPARK_OPTS__": "--master k8s://https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} --deploy-mode cluster --name ${KERNEL_USERNAME}-${KERNEL_ID} --kubernetes-namespace ${KERNEL_NAMESPACE} --driver-memory 2G --conf spark.kubernetes.driver.label.app=enterprise-gateway --conf spark.kubernetes.driver.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.driver.label.component=kernel --conf spark.kubernetes.executor.label.app=enterprise-gateway --conf spark.kubernetes.executor.label.kernel_id=${KERNEL_ID} --conf spark.kubernetes.executor.label.component=kernel --conf spark.kubernetes.driver.docker.image=${EG_KUBERNETES_KERNEL_IMAGE} --conf spark.kubernetes.executor.docker.image=${EG_KUBERNETES_KERNEL_EXECUTOR_IMAGE} --conf spark.kubernetes.submission.waitAppCompletion=false",
     "__TOREE_OPTS__": "--alternate-sigint USR2",
     "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"
@@ -20,6 +20,8 @@
     "--profile",
     "{connection_file}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}"
+    "{response_address}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "eager"
   ]
 }


### PR DESCRIPTION
One of the changes that occurred while kubernetes was on a separate branch
was the introduction of spark-context-initialization-mode.  These changes
include that update as well as the following found during testing:

1. Spark scala kubernetes kernels must create their spark context using the
eager mode.  For whatever reason, the Toree lazy initialization change does
not work via the spark-on-k8s fork.  However, eager works fine.  We can revist
once we switch to the Spark 2.3 code.

2. There weren't any Toree assembly files in the enterprise-gateway image. As
a result, the code that allows us to avoid pinning to specific versions doesn't
work because it requires that the assembly be present.  The Dockerfile has been
updated accordingly.

3. Added the changes from the other scala kernels that checks for the existence
of the toree assembly and launcher jar.

4. Updated handle_timeout() in processproxy.py since it wasn't using the changes
made to throw better error messages.

Fixes #366