### PR TITLE
Configure non-root user for kubernetes images

### DIFF
--- a/etc/docker/kubernetes-enterprise-gateway/Dockerfile
+++ b/etc/docker/kubernetes-enterprise-gateway/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev curl
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp
 RUN pip install cffi kubernetes send2trash /tmp/jupyter_enterprise_gateway*.whl && \
+    pip install requests --upgrade && \
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
@@ -20,11 +21,14 @@ RUN cd /tmp && \
 COPY start-enterprise-gateway.sh.template /usr/local/share/jupyter
 COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh
 
-RUN chown root.root /etc/bootstrap-enterprise-gateway.sh && \
-	chmod 0700 /etc/bootstrap-enterprise-gateway.sh && \
+RUN addgroup -S -g 619 eg-svc && adduser -S -u 619 -G eg-svc eg-svc && \
+    chown eg-svc.eg-svc /etc/bootstrap-enterprise-gateway.sh && \
+	chmod 0755 /etc/bootstrap-enterprise-gateway.sh && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
-	chmod 0777 /usr/local/share/jupyter/enterprise-gateway.log
+	chown -R eg-svc.eg-svc /usr/local/share/jupyter && \
+	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
 
+USER eg-svc
 
 ENTRYPOINT ["/etc/bootstrap-enterprise-gateway.sh"]
 

--- a/etc/docker/kubernetes-kernel-py/Dockerfile
+++ b/etc/docker/kubernetes-kernel-py/Dockerfile
@@ -5,6 +5,13 @@ RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev && \
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 
-COPY *.sh /etc/
+COPY bootstrap-kernel.sh spark-exec.sh /etc/
+
+RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \
+    chown eg-kernel.eg-kernel /etc/bootstrap-kernel.sh /etc/spark-exec.sh && \
+	chmod 0755 /etc/bootstrap-kernel.sh /etc/spark-exec.sh && \
+	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter /opt/spark/work-dir
+
+USER eg-kernel
 
 CMD /etc/spark-exec.sh

--- a/etc/docker/kubernetes-kernel-r/Dockerfile
+++ b/etc/docker/kubernetes-kernel-r/Dockerfile
@@ -12,3 +12,14 @@ ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 # Use our bootstrap file.  Kubernetes kernel yaml will reference this file
 # as the image's CMD in the k8s context.
 COPY bootstrap-kernel.sh /etc/
+
+# Switch back to root to create the kernel user
+USER root
+
+RUN addgroup --system --gid 620 eg-kernel && adduser --system --uid 620 --gid 620 eg-kernel && \
+    chown eg-kernel.eg-kernel /etc/bootstrap-kernel.sh && \
+	chmod 0755 /etc/bootstrap-kernel.sh && \
+	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter
+
+USER eg-kernel
+

--- a/etc/docker/kubernetes-kernel-scala/Dockerfile
+++ b/etc/docker/kubernetes-kernel-scala/Dockerfile
@@ -11,6 +11,13 @@ RUN cd /tmp && \
 	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/spark_scala_kubernetes/lib && \
 	rm -rf toree-0.2.0*
 
-COPY *.sh /etc/
+COPY bootstrap-kernel.sh spark-exec.sh /etc/
+
+RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \
+    chown eg-kernel.eg-kernel /etc/bootstrap-kernel.sh /etc/spark-exec.sh && \
+	chmod 0755 /etc/bootstrap-kernel.sh /etc/spark-exec.sh && \
+	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter /opt/spark/work-dir
+
+USER eg-kernel
 
 CMD /etc/spark-exec.sh

--- a/etc/docker/kubernetes-kernel-tf-py/Dockerfile
+++ b/etc/docker/kubernetes-kernel-tf-py/Dockerfile
@@ -4,5 +4,12 @@ RUN pip install pycrypto
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 
-COPY *.sh /etc/
+COPY bootstrap-kernel.sh /etc/
+
+RUN addgroup --system --gid 620 eg-kernel && adduser --system --uid 620 --gid 620 eg-kernel && \
+    chown eg-kernel.eg-kernel /etc/bootstrap-kernel.sh && \
+	chmod 0755 /etc/bootstrap-kernel.sh && \
+	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter
+
+USER eg-kernel
 

--- a/etc/docker/kubernetes-spark-kernel-r/Dockerfile
+++ b/etc/docker/kubernetes-spark-kernel-r/Dockerfile
@@ -18,7 +18,14 @@ RUN mkdir -p /usr/share/doc/R/html && \
 # Install OOTB kernelspecs
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 
-COPY *.sh /etc/
+COPY spark-exec.sh /etc/
+
+RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \
+    chown eg-kernel.eg-kernel /etc/spark-exec.sh && \
+	chmod 0755 /etc/spark-exec.sh && \
+	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter /opt/spark/work-dir
+
+USER eg-kernel
 
 ENV R_LIBS_USER ${R_HOME}/library:${SPARK_HOME}/R/lib
 


### PR DESCRIPTION
Since docker containers run as the root user by default, its a best practice
to run containers as non-root users.  This PR does that by configuring the
user `eg-svc` (UID 619) for the kubernetes-enterprise-gateway image and user
`eg-kernel` (UID 620) for the kubernetes-kernel images.  A correspondingly
named group is associated with each as well.

All files and working directories also have their ownership and permissions
changed approriately.

Please note that general testing has been performed.  We may find additional
permission changes necessary as we begin to use persistent volumes and other
'touch points'.

Fixes #382