### PR TITLE
Allow access from remote hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,9 @@ endif
 	($(SA) $(ENV) && GATEWAY_HOST=$(ITEST_HOST) KERNEL_USERNAME=$(ITEST_USER) nosetests -v enterprise_gateway.itests)
 	@echo "Run \`docker logs itest\` to see enterprise-gateway log."
 
+PREP_TIMEOUT?=60
 docker-prep: 
 	@-docker rm -f itest >> /dev/null
 	@echo "Starting enterprise-gateway container (run \`docker logs itest\` to see container log)..."
 	@-docker run -itd -p 8888:8888 -h itest --name itest -v `pwd`/enterprise_gateway/itests:/tmp/byok elyra/enterprise-gateway:$(ENTERPRISE_GATEWAY_TAG) --elyra
-	@(r="1"; attempts=0; while [ "$$r" == "1" -a $$attempts -lt 30 ]; do echo "Waiting for enterprise-gateway to start..."; sleep 2; ((attempts++)); docker logs itest |grep 'Jupyter Enterprise Gateway at http'; r=$$?; done; if [ $$attempts -ge 30 ]; then echo "Wait for startup timed out!"; exit 1; fi;)
+	@(r="1"; attempts=0; while [ "$$r" == "1" -a $$attempts -lt $(PREP_TIMEOUT) ]; do echo "Waiting for enterprise-gateway to start..."; sleep 2; ((attempts++)); docker logs itest |grep 'Jupyter Enterprise Gateway at http'; r=$$?; done; if [ $$attempts -ge $(PREP_TIMEOUT) ]; then echo "Wait for startup timed out!"; exit 1; fi;)

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -238,12 +238,21 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
         self.personality.init_configurables()
 
+    def init_webapp(self):
+        super(EnterpriseGatewayApp, self).init_webapp()
+
+        # As of Notebook 5.6, remote kernels are prevented: https://github.com/jupyter/notebook/pull/3714/ unless
+        # 'allow_remote_access' is enabled.  Since this is the entire purpose of EG, we'll unconditionally set that
+        # here.  Because this is a dictionary, we shouldn't have to worry about older versions as this will be ignored.
+        self.web_app.settings['allow_remote_access'] = True
+
     def start(self):
         """Starts an IO loop for the application. """
 
         # Note that we *intentionally* reference the KernelGatewayApp so that we bypass
         # its start() logic and just call that of JKG's superclass.
         super(KernelGatewayApp, self).start()
+
         self.log.info('Jupyter Enterprise Gateway at http{}://{}:{}'.format(
             's' if self.keyfile else '', self.ip, self.port
         ))

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -3,6 +3,7 @@ FROM elyra/yarn-spark:2.1.0
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp
 RUN pip install /tmp/jupyter_enterprise_gateway*.whl && \
+    pip install --upgrade ipykernel jupyter-client notebook && \
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/


### PR DESCRIPTION
[Notebook PR 3714](https://github.com/jupyter/notebook/pull/3714/) in 5.6.0 has code that prevents remote host access.  Since
the entire purpose of Enterprise Gateway is to allow remote host access, we need
to enable the web setting `allow_remote_access` to prevent the 403 exception.
This was discovered due to recent Travis build failures since it uses updated resources.

This led to other dependency related issues, namely in the docker image used for
testing leading to the update of the jupyter framework files in the `Dockerfile`.

Also increased the timeout for waiting for the docker image startup from 30
to 60 seconds and added the ability to override on the command line using
`PREP_TIMEOUT=n`.