### PR TITLE
Update java build in yarn-spark image

### DIFF
--- a/etc/docker/yarn-spark/Dockerfile
+++ b/etc/docker/yarn-spark/Dockerfile
@@ -15,10 +15,10 @@ RUN cd /tmp && \
 
 # Update Java
 RUN cd /tmp && \
-	curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
+	curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
 	rpm -e jdk-1.7.0_71-fcs.x86_64 && \
-	rpm -i /tmp/jdk-8u172-linux-x64.rpm && \
-	rm -f /tmp/jdk-8u172-linux-x64.rpm
+	rpm -i /tmp/jdk-8u181-linux-x64.rpm && \
+	rm -f /tmp/jdk-8u181-linux-x64.rpm
 
 
 # Install Anaconda


### PR DESCRIPTION
The link for the previous java build (8u172-b11) stopped working.  This
PR updates the build to jdk 8u181-b13.

Fixes #390