### PR TITLE
Fix references to kubernetes yaml file

### DIFF
--- a/docs/source/docker.md
+++ b/docs/source/docker.md
@@ -63,7 +63,7 @@ the [Enterprise Gateway organization](https://hub.docker.com/r/elyra/) on docker
 ### elyra/kubernetes-enterprise-gateway
 The primary image for Kubernetes support, [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/) 
 contains the Enterprise Gateway server software and default kernelspec files.  Its deployment is completely a function 
-of the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file
+of the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file
 
 We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container
 since we've found those to require post-deployment modifications from time to time.

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -29,7 +29,7 @@ The service is currently configured as type `NodePort` but is intended for type
 are stateful, the service is also configured with a `sessionAffinity` of `ClientIP`.  As
 a result, kernel creation requests will be routed to different deployment instances (see 
 deployment) thereby diminishing the need for a `LoadBalancer` type. Here's the service 
-yaml entry from [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml):
+yaml entry from [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml):
 ```yaml
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ spec:
 The deployment yaml essentially houses the pod description.  By increasing the number of `replicas`
 a configuration can experience instant benefits of distributing enterprise-gateway instances across 
 the cluster.  This implies that once session persistence is provided, we should be able to provide 
-highly available (HA) kernels.  Here's the yaml portion from [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml)
+highly available (HA) kernels.  Here's the yaml portion from [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml)
 that defines the Kubernetes deployment and pod (some items may have changed):
 ```yaml
 apiVersion: apps/v1beta2
@@ -99,7 +99,7 @@ _[Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volu
 it available to all pods within the Kubernetes cluster.
 
 As an example, we have included a stanza for creating a Persistent Volume (PV) and Persistent Volume 
-Claim (PVC), along with appropriate references to the PVC within each pod definition within [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml).
+Claim (PVC), along with appropriate references to the PVC within each pod definition within [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml).
  By default, these references are commented out as they require
 the system administrator configure the appropriate PV type (e.g., nfs) and server IP.
 
@@ -138,7 +138,7 @@ spec:
 Once a Persistent Volume and Persistent Volume Claim have been created, pods that desire mounting
 the volume can simply refer to it by its PVC name.
 
-Here you can see how `kubernetes-enterprise-gateway.yaml` references use of the volume (via `volumeMounts`
+Here you can see how `enterprise-gateway.yaml` references use of the volume (via `volumeMounts`
 for the container specification and `volumes` in the pod specification):
 ```yaml
     spec:
@@ -323,11 +323,11 @@ docker pull elyra/kubernetes-kernel-py:dev
 
 **Note:** It is important to pre-seed the worker nodes with **all** kernel images, otherwise the automatic download 
 time will count against the kernel's launch timeout.  Although this will likely only impact the first launch of a given 
-kernel on a given work node, when multiplied against the number of kernels and worker nodes, it will prove to be a 
+kernel on a given worker node, when multiplied against the number of kernels and worker nodes, it will prove to be a 
 frustrating user experience. 
 
 If it is not possible to pre-seed the nodes, you will likely need to adjust the `EG_KERNEL_LAUNCH_TIMEOUT` value 
-in the `kubernetes-enterprise-gateway.yaml` file as well as the `KG_REQUEST_TIMEOUT` parameter that issue the kernel 
+in the `enterprise-gateway.yaml` file as well as the `KG_REQUEST_TIMEOUT` parameter that issue the kernel 
 start requests from the `NB2KG` extension of the Notebook client.
 
 ##### Create the Enterprise Gateway kubernetes service and deployment
@@ -335,7 +335,7 @@ From the master node, create the service and deployment using the yaml file from
 repository:
 
 ```
-kubectl apply -f etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml
+kubectl apply -f etc/kubernetes/enterprise-gateway.yaml
 
 service "enterprise-gateway" created
 deployment "enterprise-gateway" created
@@ -364,7 +364,7 @@ the cluster-ip entry (e.g.,`10.110.253.220`).
 five-character suffixes.)
 
 **Tip:** You can avoid the need to point at a different port each time EG is launched by adding an
-`externalIPs:` entry to the `spec:` section of the `kubernetes-enterprise-gateway.yaml` file.  The
+`externalIPs:` entry to the `spec:` section of the `enterprise-gateway.yaml` file.  The
 file is delivered with this entry commented out.  Of course, you'll need to change the IP address
 to that of your kubernetes master node once the comments characters have been removed.
 ```text

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -278,7 +278,7 @@ With the popularity of Kubernetes within the enterprise, Enterprise Gateway now 
 of a process proxy that communicates with the Kubernetes resource manager via the Kubernetes API.  Unlike
 the other offerings, in the case of Kubernetes, Enterprise Gateway is itself deployed within the Kubernetes
 cluster as a *Service* and *Deployment*.  The primary vehicle by which this is accomplished is via the
-[kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) 
+[enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) 
 file that contains the necessary metadata to define its deployment.  
 
 See 

--- a/etc/docker/kubernetes-enterprise-gateway/README.md
+++ b/etc/docker/kubernetes-enterprise-gateway/README.md
@@ -7,8 +7,8 @@ This image adds support for [Jupyter Enterprise Gateway](http://jupyter-enterpri
 # Basic Use
 Pull this image, along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 For more information, check our [repo](https://github.com/jupyter-incubator/enterprise_gateway) and [docs](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kubernetes-kernel-py/README.md
+++ b/etc/docker/kubernetes-kernel-py/README.md
@@ -7,9 +7,9 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # Basic Use
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against  the Enterprise Gateway instance and pick either of the python-related kernels.
 

--- a/etc/docker/kubernetes-kernel-r/README.md
+++ b/etc/docker/kubernetes-kernel-r/README.md
@@ -6,9 +6,9 @@ This image enables the use of an IRKernel kernel launched from [Jupyter Enterpri
 # Basic Use
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against the Enterprise Gateway instance and pick either of the python-related kernels.
 

--- a/etc/docker/kubernetes-kernel-scala/README.md
+++ b/etc/docker/kubernetes-kernel-scala/README.md
@@ -8,9 +8,9 @@ This image enables the use of a Scala ([Apache Toree](http://toree.apache.org/))
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and
 image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against the Enterprise Gateway instance and pick either of the scala-related kernels.
 

--- a/etc/docker/kubernetes-kernel-tf-gpu-py/README.md
+++ b/etc/docker/kubernetes-kernel-tf-gpu-py/README.md
@@ -6,9 +6,9 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # Basic Use
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against  the Enterprise Gateway instance and pick either of the python-related kernels.
 

--- a/etc/docker/kubernetes-kernel-tf-py/README.md
+++ b/etc/docker/kubernetes-kernel-tf-py/README.md
@@ -6,9 +6,9 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # Basic Use
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against  the Enterprise Gateway instance and pick either of the python-related kernels.
 

--- a/etc/docker/kubernetes-spark-kernel-r/README.md
+++ b/etc/docker/kubernetes-spark-kernel-r/README.md
@@ -7,9 +7,9 @@ This image enables the use of an IRKernel kernel launched from [Jupyter Enterpri
 # Basic Use
 Pull [elyra/kubernetes-enterprise-gateway](https://hub.docker.com/r/elyra/kubernetes-enterprise-gateway/), along with all of the elyra/kubernetes-kernel-* images to each of your kubernetes nodes.  Although manual seeding of images across the cluster is not required, it is highly recommended since kernel startup times can timeout and image downloads can seriously undermine that window.
 
-Download the [kubernetes-enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/docker/kubernetes-enterprise-gateway/kubernetes-enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
+Download the [enterprise-gateway.yaml](https://github.com/jupyter-incubator/enterprise_gateway/blob/master/etc/kubernetes/enterprise-gateway.yaml) file and make any necessary changes for your configuration.  We recommend that a persistent volume be used so that the kernelspec files can be accessed outside of the container since we've found those to require post-deployment modifications from time to time.
 
-Deploy Jupyter Enterprise Gateway using `kubectl apply -f kubernetes-enterprise-gateway.yaml`
+Deploy Jupyter Enterprise Gateway using `kubectl apply -f enterprise-gateway.yaml`
 
 Launch a Jupyter Notebook application using NB2KG (see [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) against the Enterprise Gateway instance and pick either of the python-related kernels.
 


### PR DESCRIPTION
A recent change to the kubernetes build invalidated the location of the
`enterprise-gateway.yaml` file that is referenced in all of the kubernetes
image README files and online docs.  These changes correct those references.