### PR TITLE
Detect launch failures prior to timeout

### DIFF
--- a/enterprise_gateway/services/processproxies/conductor.py
+++ b/enterprise_gateway/services/processproxies/conductor.py
@@ -204,6 +204,8 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
 
                 if self.assigned_host != '':
                     ready_to_connect = self.receive_connection_info()
+            else:
+                self.detect_launch_failure()
 
     def get_application_state(self):
         # Gets the current application state using the application_id already obtained.  Once the assigned host

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -145,6 +145,7 @@ class KubernetesProcessProxy(RemoteProcessProxy):
                     self.pid = 0  # We won't send process signals for kubernetes lifecycle management
                     self.pgid = 0
             else:
+                self.detect_launch_failure()
                 self.log.debug("{}: Waiting to connect to k8s pod in namespace '{}'. "
                                "Name: '{}', Status: 'None', Pod IP: 'None', Host IP: 'None', KernelID: '{}'".
                                format(i, self.kernel_namespace, self.pod_name, self.kernel_id))

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -239,7 +239,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
                     result = self.local_signal(signal.SIGTERM)
                 else:
                     result = self.remote_signal(signal.SIGTERM)
-            self.log.debug("SIGTERM signal sent to pid: {}".format(self.pid))
+                self.log.debug("SIGTERM signal sent to pid: {}".format(self.pid))
         return result
 
     @staticmethod
@@ -588,6 +588,29 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
     @abc.abstractmethod
     def confirm_remote_startup(self, kernel_cmd, **kw):
         pass
+
+    def detect_launch_failure(self):
+        """
+        Helper method called from implementations of confirm_remote_startup() that checks if
+        self.local_proc (a popen instance) has terminated prior to the confirmation of startup.
+        This prevents users from having to wait for the kernel timeout duration to know if the
+        launch fails.  It also helps distinguish local invocation issues from remote post-launch
+        issues since the failure will be relatively immediate.
+
+        Note that this method only applies to those process proxy implementations that launch
+        from the local node.  Proxies like DistributedProcessProxy using rsh against a remote
+        node, so there's not `local_proc` in play to interrogate.
+        """
+
+        # Check if the local proc has faulted (poll() will return non-None with a non-zero return
+        # code in such cases).  If a fault was encountered, raise server error (500) with a message
+        # indicating to check the EG log for more information.
+        if self.local_proc and self.local_proc.poll() > 0:
+            self.local_proc.wait()
+            error_message = "Error occurred during launch of KernelID: {}.  " \
+                            "Check Enterprise Gateway log for more information.".format(self.kernel_id)
+            self.local_proc = None
+            self.log_and_raise(http_status_code=500, reason=error_message)
 
     def _prepare_response_socket(self):
         s = self.select_socket(local_ip)

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -162,6 +162,8 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
 
                 if self.assigned_host != '':
                     ready_to_connect = self.receive_connection_info()
+            else:
+                self.detect_launch_failure()
 
     def get_application_state(self):
         # Gets the current application state using the application_id already obtained.  Once the assigned host


### PR DESCRIPTION
Created a helper method (`detect_launch_failure()`) that checks if the popen instance
has terminated prior to the confirmation of startup.  This prevents users from having
to wait for the kernel timeout duration to know if the launch fails.  It also helps
distinguish local invocation issues from remote post-launch issues since the failure
will be relatively immediate.  Process proxy implementations will call this helper
method from their `confirm_remote_startup()` method while looking for the remote
application  Process proxy implementations will call this helper
method from their `confirm_remote_startup()` method while looking for the remote
application.

Note that this method only applies to those process proxy implementations that launch
from the local node.  Proxies like DistributedProcessProxy use rsh against a remote
node, so there's not `local_proc` in play to interrogate.

I recommend we target this for the 1.0.0 release since it helps with troubleshooting,
especially since most configuration-related issues will occur in this window.

Fixes #402