### PR TITLE
Remove obsolete code that downloads Toree assembly

### DIFF
--- a/etc/docker/kubernetes-enterprise-gateway/Dockerfile
+++ b/etc/docker/kubernetes-enterprise-gateway/Dockerfile
@@ -10,14 +10,6 @@ RUN pip install cffi kubernetes send2trash /tmp/jupyter_enterprise_gateway*.whl 
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 
-# Install Toree for both vanilla and cluster - although these are not used except for runtime discovery.
-RUN cd /tmp && \
-	curl -O https://dist.apache.org/repos/dist/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz && \
-	tar xf toree-0.2.0.tar.gz && \
-	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/scala_kubernetes/lib && \
-	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/spark_scala_kubernetes/lib && \
-	rm -rf toree-0.2.0*
-
 COPY start-enterprise-gateway.sh.template /usr/local/share/jupyter
 COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh
 

--- a/etc/docker/kubernetes-kernel-scala/Dockerfile
+++ b/etc/docker/kubernetes-kernel-scala/Dockerfile
@@ -2,15 +2,6 @@ FROM kubespark/spark-driver:v2.2.0-kubernetes-0.5.0
 
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
 
-# Install Toree for both vanilla and cluster
-RUN cd /tmp && \
-    apk --no-cache add curl && \
-	curl -O https://dist.apache.org/repos/dist/release/incubator/toree/0.2.0-incubating/toree-pip/toree-0.2.0.tar.gz && \
-	tar xf toree-0.2.0.tar.gz && \
-	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/scala_kubernetes/lib && \
-	cp toree-0.2.0/toree/lib/toree-assembly-0.2.0-incubating.jar /usr/local/share/jupyter/kernels/spark_scala_kubernetes/lib && \
-	rm -rf toree-0.2.0*
-
 COPY bootstrap-kernel.sh spark-exec.sh /etc/
 
 RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \


### PR DESCRIPTION
Now that Toree assembly is already part of the kernelspecs
distribution we don't need to manually add the jar into
lib folder.