### PR TITLE
Fix python_tf_gpu_kubernetes kernelspec

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -34,11 +34,15 @@ kernelspecs: $(KERNELSPECS_FILE) ## Make a tar.gz file consisting of kernelspec 
 
 $(KERNELSPECS_FILE): $(KERNELSPECS_FILES) kernel-launchers/scala/lib  
 	@mkdir -p ../build/kernelspecs
+        # Seed the build tree with initial files
 	cp -r kernelspecs ../build
+        # Distribute language and config-sensitive files.
 	@echo ../build/kernelspecs/{spark_,}python_* | xargs -t -n 1 cp -r kernel-launchers/python/*
 	@echo ../build/kernelspecs/{spark_,}R_* | xargs -t -n 1 cp -r kernel-launchers/R/*
 	@echo ../build/kernelspecs/{spark_,}scala_* | xargs -t -n 1 cp -r kernel-launchers/scala/lib
-	@echo ../build/kernelspecs/{python,R,scala,python_tf}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
+	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
+        # Perform the copy again to enable local, per-kernel, overrides
+	cp -r kernelspecs ../build
 	@mkdir -p ../dist
 	rm -f $(KERNELSPECS_FILE)
 	@( cd ../build/kernelspecs; tar -pvczf "../$(KERNELSPECS_FILE)" * )

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -4,7 +4,7 @@
   "process_proxy": {
     "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
     "config": {
-      "image_name": "elyra/kubernetes-kernel-tf-py-gpu:dev"
+      "image_name": "elyra/kubernetes-kernel-tf-gpu-py:dev"
     }
   },
   "env": {


### PR DESCRIPTION
Fixed the image referenced in the kernel.json file to match that produced
by the build and in dockerhub.

Fixed the Makefile to include the python_tf_gpu_kubernetes directory in the
set of directories that require extension with kernel-pod.yaml and k8s
launch script.

Perform a second copy of source directories at end to allow per-kernel overrides
of files that are otherwise generic.  This would allow for, say, the python_tf_gpu
kernelspec directory to contain its own kernel-pod.yaml file that contains pod-
specific information.  Although not ideal, due to the redundancy it introduces
with the default kernel-pod.yaml file, it does allow for finer-grained customization
in a straightforward manner.

Fixes #425