### PR TITLE
Add ability to use kernelspec.env for default values

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -351,3 +351,16 @@ access at the kernel level_.  These values apply to **all** process-proxy kernel
 * `port_range`: This process proxy configuration entry can be used to override `--EnterpriseGatewayApp.port_range`.
 Any values specified in the config dictionary override the globally defined values.  These apply to all
 `RemoteProcessProxy` kernels.
+
+### Per-kernel Environment Overrides
+In some cases, it is useful to allow specific values that exist in a kernel.json `env` stanza to be
+overridden on a per-kernel basis.  For example, if the kernelspec supports resource limitations you
+may want to allow some requests to have access to more memory or GPUs than another.  Enterprise
+Gateway enables this capability by honoring environment variables provided in the json request over
+those same-named variables in the kernel.json `env` stanza.
+
+Environment variables for which this can occur are any variables prefixed with `KERNEL_`
+(with the exception of the internal `KERNEL_GATEWAY` variable) as well as any variables
+listed in the `--JupyterWebsocketPersonality.env_whitelist` command-line option (or via
+the `KG_ENV_WHITELIST` variable).  Locally defined variables listed in `KG_PROCESS_ENV_WHITELIST`
+are also honored.

--- a/enterprise_gateway/tests/__init__.py
+++ b/enterprise_gateway/tests/__init__.py
@@ -8,4 +8,8 @@ def teardown():
     As a stopgap, force a cleanup here.
     """
     ioloop.IOLoop.current().stop()
-    ioloop.IOLoop.current().close(True)
+    # Close is not necessary since process termination closes the loop.  This was causing intermittent
+    # `Event loop is closed` exceptions.  These didn't affect the test resutls, but produced output that
+    # was otherwise misleading noise.
+    # ioloop.IOLoop.current().close(True)
+

--- a/enterprise_gateway/tests/resources/kernels/kernel_defaults_test/kernel.json
+++ b/enterprise_gateway/tests/resources/kernels/kernel_defaults_test/kernel.json
@@ -1,0 +1,19 @@
+{
+  "display_name": "Kernel Defaults Testing",
+  "language": "python",
+  "env": {
+    "KERNEL_VAR1": "kernel_var1_default",
+    "KERNEL_VAR2": "kernel_var2_default",
+    "OTHER_VAR1": "other_var1_default",
+    "OTHER_VAR2": "other_var2_default",
+    "PROCESS_VAR1": "process_var1_default",
+    "PROCESS_VAR2": "process_var2_default"
+  },
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ]
+}


### PR DESCRIPTION
Prior to this change, any values in the env stanza of a kernelspec would
override values provided by the caller in the json's env section - thereby
eliminating the ability to let those values defined in the kernelspec to
be used as defaults and the user-provided values used as overrides. Following
this change any json env's prefixed with KERNEL_ or appearing in the
KG_ENV_WHITELIST or KG_PROCESS_ENV_WHITELIST will be added back into the
kernel's env after it has been seeded with values from the kernelspec.  The
only exception to this is the internally defined KERNEL_GATEWAY variable which
is set to '1' to indicate the kernel was launched by the gateway.

Added test to validate this behavior.  This test requires use of locally
defined kernelspec so I added the ability to define such kernelspecs and
leverage setting of JUPYTER_PATH to the resources directory where the
kernelspecs reside.

Also removed close of ioloop that was (I believe) causing `loop is closed`
exceptions that side-affected test output.  This should not be necessary
since the ioloop is closed on process termination anyway.