### PR TITLE
Update DistributedProcessProxy to not use ssh if host is local server

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -111,6 +111,28 @@ class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
 
+class TestPythonKernelDistributed(unittest.TestCase, PythonKernelBaseTestCase):
+    KERNELSPEC = os.getenv("PYTHON_KERNEL_DISTRIBUTED_NAME", "python_distributed")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPythonKernelDistributed, cls).setUpClass()
+        print('>>>')
+        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # initialize environment
+        cls.gatewayClient = GatewayClient()
+        cls.kernel = cls.gatewayClient.start_kernel(cls.KERNELSPEC)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestPythonKernelDistributed, cls).tearDownClass()
+        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
+        # shutdown environment
+        cls.gatewayClient.shutdown_kernel(cls.kernel)
+
+
 class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseYarnTestCase):
     KERNELSPEC = os.getenv("PYTHON_KERNEL_CLIENT_NAME", "spark_python_yarn_client")
 

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -5,8 +5,10 @@
 import os
 import json
 import time
+from subprocess import STDOUT
 from socket import *
-from .processproxy import RemoteProcessProxy
+from jupyter_client import launch_kernel
+from .processproxy import RemoteProcessProxy, BaseProcessProxyABC
 
 poll_interval = float(os.getenv('EG_POLL_INTERVAL', '0.5'))
 kernel_log_dir = os.getenv("EG_KERNEL_LOG_DIR", '/tmp')  # would prefer /var/log, but its only writable by root
@@ -26,70 +28,88 @@ class DistributedProcessProxy(RemoteProcessProxy):
     def launch_process(self, kernel_cmd, **kw):
         super(DistributedProcessProxy, self).launch_process(kernel_cmd, **kw)
 
-        self.assigned_host = self.determine_next_host()
+        self.assigned_host = self._determine_next_host()
         self.ip = gethostbyname(self.assigned_host)  # convert to ip if host is provided
         self.assigned_ip = self.ip
 
-        cmd = self.build_startup_command(kernel_cmd, **kw)
-        self.log.debug("Invoking cmd: '{}' on host: {}".format(cmd, self.assigned_host))
-        result_pid = 'bad_pid'  # purposely initialize to bad int value
-
         try:
-            result = self.rsh(self.ip, cmd)
-        except Exception as e:
-            error_message = "Failure occurred starting remote kernel on '{}'. Exception: '{}'.".format(self.ip, e)
-            self.log_and_raise(http_status_code=500, reason=error_message)
-
-        for line in result:
-            result_pid = line.strip()
-
-        try:
+            result_pid = self._launch_remote_process(kernel_cmd, **kw)
             self.pid = int(result_pid)
-        except ValueError:
-            error_message = "Failure occurred starting remote kernel on '{}'.  Returned result: {}".\
-                format(self.ip, result)
+        except Exception as e:
+            error_message = "Failure occurred starting kernel on '{}'.  Returned result: {}".\
+                format(self.ip, e)
             self.log_and_raise(http_status_code=500, reason=error_message)
 
-        self.log.info("Remote kernel launched on '{}', pid: {}, ID: {}, Log file: {}:{}, Command: '{}'.  ".
+        self.log.info("Kernel launched on '{}', pid: {}, ID: {}, Log file: {}:{}, Command: '{}'.  ".
                       format(self.assigned_host, self.pid, self.kernel_id, self.assigned_host, self.kernel_log, kernel_cmd))
         self.confirm_remote_startup(kernel_cmd, **kw)
 
         return self
 
-    def build_startup_command(self, argv_cmd, **kw):
+    def _launch_remote_process(self, kernel_cmd, **kw):
+        """
+            Launch the kernel as indicated by the argv stanza in the kernelspec.  Note that this method
+            will bypass use of ssh if the remote host is also the local machine.
+        """
+
+        cmd = self._build_startup_command(kernel_cmd, **kw)
+        self.log.debug("Invoking cmd: '{}' on host: {}".format(cmd, self.assigned_host))
+        result_pid = 'bad_pid'  # purposely initialize to bad int value
+
+        if BaseProcessProxyABC.ip_is_local(self.ip):
+            # launch the local command with redirection in place
+            self.local_proc = launch_kernel(cmd, stdout=open(self.kernel_log, mode='w'), stderr=STDOUT, **kw)
+            result_pid = str(self.local_proc.pid)
+        else:
+            # launch remote command via ssh
+            result = self.rsh(self.ip, cmd)
+            for line in result:
+                result_pid = line.strip()
+
+        return result_pid
+
+    def _build_startup_command(self, argv_cmd, **kw):
         """
         Builds the command to invoke by concatenating envs from kernelspec followed by the kernel argvs.
 
         We also force nohup, redirection to a file and place in background, then follow with an echo
         for the background pid.
+
+        Note: We optimize for the local case and just return the existing command.
         """
-        cmd = ''
-        # Add additional envs not in kernelspec...
+
+        # Optimized case needs to also redirect the kernel output, so unconditionally compose kernel_log
         env_dict = kw['env']
-
-        kuser = env_dict.get('KERNEL_USERNAME')
-        if kuser:
-            cmd += 'export KERNEL_USERNAME="{}";'.format(kuser)
         kid = env_dict.get('KERNEL_ID')
-        if kid:
-            cmd += 'export KERNEL_ID="{}";'.format(kid)
-        impersonation = env_dict.get('EG_IMPERSONATION_ENABLED')
-        if impersonation:
-            cmd += 'export EG_IMPERSONATION_ENABLED="{}";'.format(impersonation)
-
-        for key, value in self.kernel_manager.kernel_spec.env.items():
-            cmd += "export {}={};".format(key, json.dumps(value).replace("'", "''"))
-
-        cmd += 'nohup'
-        for arg in argv_cmd:
-            cmd += ' {}'.format(arg)
-
         self.kernel_log = os.path.join(kernel_log_dir, "kernel-{}.log".format(kid))
-        cmd += ' >> {} 2>&1 & echo $!'.format(self.kernel_log)
+
+        if BaseProcessProxyABC.ip_is_local(self.ip):  # We're local so just use what we're given
+            cmd = argv_cmd
+        else:  # Add additional envs, including those in kernelspec
+            cmd = ''
+            if kid:
+                cmd += 'export KERNEL_ID="{}";'.format(kid)
+
+            kuser = env_dict.get('KERNEL_USERNAME')
+            if kuser:
+                cmd += 'export KERNEL_USERNAME="{}";'.format(kuser)
+
+            impersonation = env_dict.get('EG_IMPERSONATION_ENABLED')
+            if impersonation:
+                cmd += 'export EG_IMPERSONATION_ENABLED="{}";'.format(impersonation)
+
+            for key, value in self.kernel_manager.kernel_spec.env.items():
+                cmd += "export {}={};".format(key, json.dumps(value).replace("'", "''"))
+
+            cmd += 'nohup'
+            for arg in argv_cmd:
+                cmd += ' {}'.format(arg)
+
+            cmd += ' >> {} 2>&1 & echo $!'.format(self.kernel_log)  # return the process id
 
         return cmd
 
-    def determine_next_host(self):
+    def _determine_next_host(self):
         next_host = self.hosts[DistributedProcessProxy.host_index % self.hosts.__len__()]
         DistributedProcessProxy.host_index += 1
         return next_host

--- a/etc/docker/enterprise-gateway-demo/Dockerfile
+++ b/etc/docker/enterprise-gateway-demo/Dockerfile
@@ -12,14 +12,13 @@ COPY start-enterprise-gateway.sh.template /usr/local/share/jupyter/
 # Massage kernelspecs to docker image env...
 # Create symbolic link to preserve hdp-related directories
 # Copy toree jar from install to scala kernelspec lib directory
-# Add YARN_CONF_DIR to each env stanza, Add PATH to R-yarn-client env stanza, Add alternate-sigint to vanilla toree
+# Add YARN_CONF_DIR to each env stanza, Add alternate-sigint to vanilla toree
 RUN mkdir -p /usr/hdp/current /tmp/byok/kernels && \
 	ln -s /usr/local/spark-2.1.0-bin-hadoop2.7 /usr/hdp/current/spark2-client && \
 	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/lib && \
 	cp /usr/local/share/jupyter/kernels/spark_2.1_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib && \
 	cd /usr/local/share/jupyter/kernels && \
 	for dir in spark_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
-	cat spark_R_yarn_client/kernel.json | sed s/'"env": {'/'"env": {|    "PATH": "\/opt\/anaconda2\/bin:$PATH",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_R_yarn_client/kernel.json && \
 	cat spark_2.1_scala/kernel.json | sed s/'"__TOREE_OPTS__": "",'/'"__TOREE_OPTS__": "--alternate-sigint USR2",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_2.1_scala/kernel.json && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
 	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log

--- a/etc/docker/yarn-spark/bootstrap-yarn-spark.sh
+++ b/etc/docker/yarn-spark/bootstrap-yarn-spark.sh
@@ -40,6 +40,8 @@ sed s/HOSTNAME/$YARN_HOST/ /usr/local/hadoop/etc/hadoop/yarn-site.xml.template >
 
 # setting spark defaults
 cp $SPARK_HOME/conf/spark-defaults.conf.template  $SPARK_HOME/conf/spark-defaults.conf
+# place metastore db and derby.log in /tmp
+echo "spark.driver.extraJavaOptions -Dderby.system.home=/tmp" >>  $SPARK_HOME/conf/spark-defaults.conf
 
 cp $SPARK_HOME/conf/metrics.properties.template $SPARK_HOME/conf/metrics.properties
 

--- a/etc/kernelspecs/python_distributed/kernel.json
+++ b/etc/kernelspecs/python_distributed/kernel.json
@@ -1,0 +1,18 @@
+{
+ "display_name": "Python 2 (distributed)", 
+ "language": "python", 
+ "process_proxy": {
+   "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+ },
+ "argv": [
+   "python",
+   "/usr/local/share/jupyter/kernels/python_distributed/scripts/launch_ipykernel.py",
+   "{connection_file}",
+   "--RemoteProcessProxy.response-address",
+   "{response_address}",
+   "--RemoteProcessProxy.port-range",
+   "{port_range}",
+   "--RemoteProcessProxy.spark-context-initialization-mode",
+   "none"
+ ]
+}


### PR DESCRIPTION
DistributedProcessProxy is now "optimized" for the case when the target
host is the local server.  In such cases, use of ssh is bypassed and
kernel management is like that of the local case with the exception that
message-based interrupts still go through the communication port (in loopback).
Another advantage is that ZMQ port creation will occur much closer to the
invocation of the kernel - thereby significantly reducing the window where
port conflicts can arise.

Added example kernelspec - python_distributed - which demonstrates how the
native python kernel could be reconfigured to work in a distributed manner.

Updated integration test to exercise the distributed python kernel similar
to how the local python kernel is tested.

Found issues with the EG and Yarn images relative to the R Yarn Client
kernelspec.  Removed the addition of the PATH entry in that kernelspec's
env stanza (no other kernelspecs were doing this, can't recall why this
was necessary in the first place).  And updated the spark-conf to force
the location of the metastore_db directory and derby.log files to /tmp.
Otherwise, failures would occur (only for the R Yarn Client kernel) because
the working directory (/usr/local/share/jupyter) was not writable.