### PR TITLE
Fix kernel launch failure detection

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -605,12 +605,14 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         # Check if the local proc has faulted (poll() will return non-None with a non-zero return
         # code in such cases).  If a fault was encountered, raise server error (500) with a message
         # indicating to check the EG log for more information.
-        if self.local_proc and self.local_proc.poll() > 0:
-            self.local_proc.wait()
-            error_message = "Error occurred during launch of KernelID: {}.  " \
-                            "Check Enterprise Gateway log for more information.".format(self.kernel_id)
-            self.local_proc = None
-            self.log_and_raise(http_status_code=500, reason=error_message)
+        if self.local_proc:
+            poll_result = self.local_proc.poll()
+            if poll_result and poll_result > 0:
+                self.local_proc.wait()
+                error_message = "Error occurred during launch of KernelID: {}.  " \
+                                "Check Enterprise Gateway log for more information.".format(self.kernel_id)
+                self.local_proc = None
+                self.log_and_raise(http_status_code=500, reason=error_message)
 
     def _prepare_response_socket(self):
         s = self.select_socket(local_ip)


### PR DESCRIPTION
On python 3.x systems and reported in issues #432 and #435, the existing launch
failure detection was producing the following `TypeError` exception:

```
File "/opt/anaconda3/lib/python3.6/site-packages/enterprise_gateway/services/
             processproxies/processproxy.py", line 587, in detect_launch_failure
        if self.local_proc and self.local_proc.poll() > 0:
    TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

This change checks if the result from `poll()` is None prior to checking its
value.

NOTE: This change should be added to the 1.x branch for a patch release.