### PR TITLE
Fix errno error in 1.x branch

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -6,6 +6,7 @@ import os
 import sys
 import re
 import signal
+import errno
 import abc
 import json
 import paramiko
@@ -215,7 +216,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
                         result = self.local_signal(signal.SIGKILL)
                     else:
                         result = self.remote_signal(signal.SIGKILL)
-            self.log.debug("SIGKILL signal sent to pid: {}".format(self.pid))
+                self.log.debug("SIGKILL signal sent to pid: {}".format(self.pid))
         return result
 
     def terminate(self):


### PR DESCRIPTION
fix "NameError: name 'errno' is not defined"
in master already fixed by commit d61946ac3017840c947a6e54847acaf8d1ad4f4a

without this fix server return error and jupyter server don't show list of available notebooks.

small logging fix backported from the same commit