### PR TITLE
Stop tagging images with dev_x as a means of image backup

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -123,8 +123,6 @@ $(foreach image,$(IMAGES),$(eval $(call BUILD_IMAGE,$(image))))
 define CLEAN_IMAGE
 clean-$1:
 	@rm -f ../.image-$1
-	@-docker rmi -f $(HUB_ORG)/$1:$(TAG)_x
-	@-docker tag $(HUB_ORG)/$1:$(TAG) $(HUB_ORG)/$1:$(TAG)_x
 	@-docker rmi -f $(HUB_ORG)/$1:$(TAG)
 endef
 $(foreach image,$(IMAGES),$(eval $(call CLEAN_IMAGE,$(image))))


### PR DESCRIPTION
We have been retagging images with <tag>_x (typically dev_x) as
a means of retaining a copy of the previous image.  Since we have
not really found a need to rollback to the "backup" image and because
this increases disk space consumption, we will stop doing this.

Developers can clean up their dev_x tagged images via:

```
docker rmi -f `docker images |grep dev_x |awk '{print $3}'`
```